### PR TITLE
Attribute types cannot be decimal

### DIFF
--- a/doxygen/pack.dxy
+++ b/doxygen/pack.dxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Open-CMSIS-Pack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Version 1.7.5"
+PROJECT_NUMBER         = "Version 1.7.6"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -84,6 +84,12 @@ Pack\\Tutorials | Tutorials for \ref cp_Packs "Creating Packs" |
     <th>Description</th>
   </tr>
   <tr>
+    <td>1.7.6</td>
+    <td>
+     - type of n and m attributes of BoardFeatureType and Pname becomes xs:string
+    </td>
+  </tr>
+  <tr>
     <td>1.7.5</td>
     <td>
      - Rename DcoreEnum 'Star' to 'Star-MC1'

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-  Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+  Copyright (c) 2013-2022 ARM Limited. All rights reserved.
 
   SPDX-License-Identifier: Apache-2.0
 
@@ -17,13 +17,16 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-  $Date:        1. Dec 2020
+  $Date:        12. Jan 2022
   $Revision:    1.7.2
 
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
-  SchemaVersion=1.7.2
+  SchemaVersion=1.7.3
+
+  12. January 2022: v1.7.3
+   - type of n and m attributes of BoardFeatureType and Pname becomes xs:string
 
   1. December 2020: v1.7.2
    - added 'XC' to CompilerEnumType to enable use of Microchip XC32 compiler
@@ -135,7 +138,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.2">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.3">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -675,8 +675,8 @@
     <xs:attribute name="Pname" type="RestrictedString" use="optional" />
     <!-- <xs:attribute name="type"  type="DeviceFeatureTypeEnum" use="required"/> -->
     <xs:attribute name="type" type="xs:string" use="required" />
-    <xs:attribute name="n" type="xs:decimal" use="optional" />
-    <xs:attribute name="m" type="xs:decimal" use="optional" />
+    <xs:attribute name="n" type="xs:string" use="optional" />
+    <xs:attribute name="m" type="xs:string" use="optional" />
     <xs:attribute name="name" type="xs:string" use="optional" />
     <!-- deprecated, only for backwards compatibility -->
     <xs:attribute name="count" type="xs:int" use="optional" />
@@ -686,8 +686,8 @@
   <xs:complexType name="BoardFeatureType">
     <!-- <xs:attribute name="type"  type="BoardFeatureTypeEnum" use="required"/> -->
     <xs:attribute name="type" type="xs:string" use="required" />
-    <xs:attribute name="n" type="xs:decimal" use="optional" />
-    <xs:attribute name="m" type="xs:decimal" use="optional" />
+    <xs:attribute name="n" type="xs:string" use="optional" />
+    <xs:attribute name="m" type="xs:string" use="optional" />
     <xs:attribute name="name" type="xs:string" use="optional" />
   </xs:complexType>
 


### PR DESCRIPTION
# Schema Change

This pull request contributes a change to an Open-CMSIS-Pack file schema.
Schema changes have a major impact on the tool ecosystem and need to be done carefully.

## Description

The Packs schema defines two types:`DeviceFeatureType` and `BoardFeatureType`. Both define two attributes `m` and `n`. These attributes were originally assigned a type of xsd:decimal, but this is too restrictive to encompass the range of values permitted for these attributes.

For example: Representation of display resolutions, e.g. `250 x 250`
CMSIS representation: `250.250`. This (originally) parses as a float which is `250.25`, which ends up reading as `250 x 25`

## Checklist
_checklist version 2021-11-10_

- [x] Does this change implement an approved ADR?
       Minor change only, described in the section above.
- [X] Is the schema file changed, properly?
  - [X] Is the schema version incremented according to [Semantic Versioning](https://semver.org/)?
  - [X] Is the schema file header updated, version and date?
  - [X] Is the schema file change history updated?
  - [X] Does the updated schema file pass [XSD meta schema](https://www.w3.org/2012/04/XMLSchema.xsd) check?
- [x] Is the documentation updated, accordingly?
     No update required. The type is only described here, and is implicit in the existing documentation.
- [x] Are the [automatic checks](../tree/main/.github/workflows) updated or enhanced if required?
      Not required. Minor change that does not affect the workflow
- [x] Are enhancements to PackChk required to proof semantic usage of changed/added features?
      No. This is a widening of an existing type to be more lenient.
