### PR TITLE
Update SemVer.org regex in PackIndex.xsd and PACK.xsd

### DIFF
--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -17,15 +17,17 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-  $Date:        21. Apr 2022
-  $Revision:    1.7.7
+  $Date:        13. May 2022
+  $Revision:    1.7.8
 
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
 
-  SchemaVersion=1.7.7
+  SchemaVersion=1.7.8
 
+  13. May 2022: v1.7.8
+   - update pattern for PackVersionType regex to use one from semver.org
   21. April 2022: v1.7.7
    - added 'Cortex-M85' to DcoreEnum
    - added 'Dpacbti' attribute to Processor
@@ -1498,8 +1500,8 @@
   -->
   <xs:simpleType name="PackVersionType">
     <xs:restriction base="xs:string">
-      <!-- major . minor . patch [[-]quality] [+build] -->
-      <xs:pattern value="[0-9]+.[0-9]+.[0-9]+((\-[0-9A-Za-z_\-\.]+)|([_A-Za-z][0-9A-Za-z_\-\.]*)|())((\+[\-\._A-Za-z0-9]+)|())" />
+      <!--                major       . minor       . patch       [[-]quality]                                                                                     [+build]                                -->
+      <xs:pattern value="(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?" />
     </xs:restriction>
   </xs:simpleType>
 

--- a/schema/PackIndex.xsd
+++ b/schema/PackIndex.xsd
@@ -32,8 +32,8 @@
   <!-- semantic versioning (semver.org) <major>.<minor>.<patch>-<quality> -->
   <xs:simpleType name="SemanticVersionType">
     <xs:restriction  base="xs:string">
-      <!--               <major>         . <minor>        . <patch>        - <quality>                                                                                       + <build meta info>               -->
-      <xs:pattern value="(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?"/>
+      <!--               <major>      . <minor>     . <patch>       - <quality>                                                                                     + <build meta info>                   -->
+      <xs:pattern value="(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
I used the regex pattern for semver from PackIndex.xsd in cpackget for version validating and capturing. While it worked fine for validating pack versions, it contained an unexpected behavior when capturing version bits using the regex. I commented about it in this comment in cpackget issue: https://github.com/Open-CMSIS-Pack/cpackget/issues/80#issuecomment-1125214826

Visiting SemVer.org, it seems there is an updated version of this regex pattern which fixed the bug in cpackget.

I updated the regex in PackIndex.xsd with the one from SemVer.org just to keep it up to date.

Since PACK.xsd also seems to have a pattern for version, I updated the pattern there as well, but I could not find a way to validate if it will break anything after the update.