### PR TITLE
extend FileCategoryType (#28)

### DIFF
--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -84,6 +84,13 @@ Pack\\Tutorials | Tutorials for \ref cp_Packs "Creating Packs" |
     <th>Description</th>
   </tr>
   <tr>
+    <td>1.7.8</td>
+    <td>
+     - added 'includeAsm', 'includeC', 'includeCpp', 'includeLd' to FileCategoryType
+     - added 'headerAsm', 'includeC', 'headerCpp', 'headerLd' to FileCategoryType
+    </td>
+  </tr>
+  <tr>
     <td>1.7.7</td>
     <td>
      - added 'Cortex-M85' to DcoreEnum

--- a/doxygen/src/components_schema.txt
+++ b/doxygen/src/components_schema.txt
@@ -849,8 +849,44 @@ The table lists the predefined values for a file category.
     to a module using the <b>\#include</b> statement. Note: specify only those files as header files that form part of the API of the component, required to use the component</td>
   </tr>
   <tr>
+    <td class="XML-Token">headerAsm</td>
+    <td>Assembler header file used in the component. Sets an assembler include file path and adds the file name attribute to the list of files to be added
+    to a module using the <b>\#include</b> statement. Note: specify only those files as header files that form part of the API of the component, required to use the component</td>
+  </tr>
+    <tr>
+    <td class="XML-Token">headerC</td>
+    <td>C header file used in the component. Sets an C compiler include file path and adds the file name attribute to the list of files to be added
+    to a module using the <b>\#include</b> statement. Note: specify only those files as header files that form part of the API of the component, required to use the component</td>
+  </tr>
+  <tr>
+    <td class="XML-Token">headerCpp</td>
+    <td>C++ header file used in the component. Sets a C++ compiler include file path and adds the file name attribute to the list of files to be added
+    to a module using the <b>\#include</b> statement. Note: specify only those files as header files that form part of the API of the component, required to use the component</td>
+  </tr>
+  <tr>
+    <td class="XML-Token">headerLd</td>
+    <td>Linker script preprocessing header file used in the component. Sets a linker preprocessing include file path and adds the file name attribute to the list of files to be added
+    to a module using the <b>\#include</b> statement. Note: specify only those files as header files that form part of the API of the component, required to use the component</td>
+  </tr>
+  <tr>
     <td class="XML-Token">include</td>
     <td>Sets an include file path. Note: ensure that the name attribute specifies a directory and ends with a '/'.</td>
+  </tr>
+  <tr>
+    <td class="XML-Token">includeAsm</td>
+    <td>Sets an include file path for assembler command line. Note: ensure that the name attribute specifies a directory and ends with a '/'.</td>
+  </tr>
+  <tr>
+    <td class="XML-Token">includeC</td>
+    <td>Sets an include file path for C compiler command line. Note: ensure that the name attribute specifies a directory and ends with a '/'.</td>
+  </tr>
+  <tr>
+    <td class="XML-Token">includeCpp</td>
+    <td>Sets an include file path for C++ compiler command line. Note: ensure that the name attribute specifies a directory and ends with a '/'.</td>
+  </tr>
+  <tr>
+    <td class="XML-Token">includeLd</td>
+    <td>Sets an include file path for linker script preprocessing command line. Note: ensure that the name attribute specifies a directory and ends with a '/'.</td>
   </tr>
   <tr>
     <td class="XML-Token">library</td>
@@ -862,7 +898,7 @@ The table lists the predefined values for a file category.
   </tr>
   <tr>
     <td class="XML-Token">source</td>
-    <td>Startup-, system-, and other C/C++, assembler, etc. source files</td>
+    <td>Startup-, system-, and other C/C++, assembler, etc. source files. Relying on commonly used file extensions.</td>
   </tr>
   <tr>
     <td class="XML-Token">sourceC</td>

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -17,15 +17,18 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-  $Date:        21. Apr 2022
-  $Revision:    1.7.7
+  $Date:        02. Jun 2022
+  $Revision:    1.7.8
 
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
 
-  SchemaVersion=1.7.7
+  SchemaVersion=1.7.8
 
+  02. June 2022: v1.7.8
+   - added 'includeAsm', 'includeC', 'includeCpp', 'includeLd' to FileCategoryType
+   - added 'headerAsm', 'includeC', 'headerCpp', 'headerLd' to FileCategoryType
   21. April 2022: v1.7.7
    - added 'Cortex-M85' to DcoreEnum
    - added 'Dpacbti' attribute to Processor
@@ -1092,7 +1095,14 @@
     <xs:restriction base="xs:token">
       <xs:enumeration value="doc" />
       <xs:enumeration value="header" />
+      <xs:enumeration value="headerC" />
+      <xs:enumeration value="headerCpp" />
+      <xs:enumeration value="headerAsm" />
       <xs:enumeration value="include" />
+      <xs:enumeration value="includeC" />
+      <xs:enumeration value="includeCpp" />
+      <xs:enumeration value="includeAsm" />
+      <xs:enumeration value="includeLd" />
       <xs:enumeration value="library" />
       <xs:enumeration value="object" />
       <xs:enumeration value="source" />

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -152,7 +152,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.7">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.8">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">


### PR DESCRIPTION
The original proposal was limited to adding 
`includeAsm`, `includeC`, `includeCpp` to `FileCategoryType` to be able to specifically control the include paths for assembler, c-compiler and c++ compiler command line.

REVIEW 1:
In this PR an `includeLd` is added to allow specifying include paths for the linker script preprocessing.

REVIEW 2:
In this PR the corresponding variants for FileCategoryType` `header` are added in addition to allow specifying the
- use case for the header file. A `headerC` file should be included in a C module, a `headerCpp` in a C++ module, etc.
- specifying the implicitly extracted include path to be restricted to Asm, C, C++ and linker command line.

We need to agree whether these additions are
a) relevant / meaningful
b) consistent
c) do not create unreasonable complexity for the implementation

