### PR TITLE
Addressing Issues #131, #124, #141

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This Open-CMSIS-Pack specification is part of the Common Microcontroller Softwar
 
 Linaro Project: [Open-CMSIS-Pack](https://linaro.atlassian.net/wiki/spaces/CMSIS/overview)
 
+## Access to Specification 
+
+The specification is pre-build and can be accessed here: [https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/index.html](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/index.html)
+
 ## License
 
 The Open-CMSIS-Pack project and its sub-components are licensed under Apache 2.0.

--- a/doxygen/pack.dxy
+++ b/doxygen/pack.dxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Open-CMSIS-Pack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Version 1.7.9"
+PROJECT_NUMBER         = "Version 1.7.10"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -86,8 +86,11 @@ Pack\\Tutorials | Tutorials for \ref cp_Packs "Creating Packs" |
   <tr>
     <td>1.7.10</td>
     <td>
-     - added 'includeAsm', 'includeC', 'includeCpp', 'includeLd' to FileCategoryType
-     - added 'headerAsm', 'includeC', 'headerCpp', 'headerLd' to FileCategoryType
+     - added 'includeAsm', 'includeC', 'includeCpp', 'includeLd' to FileCategoryType of the components element
+     - added 'headerAsm', 'includeC', 'headerCpp', 'headerLd' to FileCategoryType of the components element
+     - added 'uuid' to boards element to indicate a 128-bit universal ID in the debug firmware of the board
+     - added 'memory' and 'algorithm' child elements to the boards element to describe board-specific memory
+     - added 'Bvendor', 'Bname', 'Brevision' attribute to conditions element to allow board specific filtering.
     </td>
   </tr>
   <tr>

--- a/doxygen/src/boards_schema.txt
+++ b/doxygen/src/boards_schema.txt
@@ -15,6 +15,9 @@ A development board is described by the following properties:
 - \ref element_board_image "image": pictures of the board to be displayed on web pages. 
 - \ref element_board_feature "feature": categorized list of the development board's features and peripherals. 
 - \ref element_board_debugInterface "debugInterface": describing the debug capabilities. 
+- \ref element_board_memory "memory": additional memory provided by the board
+- \ref element_board_algorithm "algorithm": additional flash programming algorithms for the board-specific memory
+
 
 \b Example
 \code
@@ -124,6 +127,11 @@ This element provides information to specify the \ref createPackBoard "Board Sup
     <td>xs:string</td>
     <td>optional</td>
   </tr>
+  <td>uuid</td>
+    <td>Specifies a <a href="https://en.wikipedia.org/wiki/Universally_unique_identifier">128-bit UUID</a> that is embedded it in the debugger firmware of the board tag. Format: 8-4-4-4-12 for a total of 36 characters. Example: 123e4567-e89b-12d3-a456-426614174000</td>
+    <td>xs:string</td>
+    <td>optional</td>
+  </tr>
   <tr>
     <td>salesContact</td>
     <td>Either an email address or web page to contact the sales department.</td>
@@ -183,6 +191,18 @@ This element provides information to specify the \ref createPackBoard "Board Sup
 	<td>Describes the documentation files (user manuals, schematics, etc.). Directory and file names are case-sensitive.</td>
 	<td>BoardsBookType</td>
 	<td>1..* </td>
+  </tr>
+  <tr>
+    <td>\ref element_board_memory "memory"</td>
+    <td>Specify memory areas that board specific.</td>
+    <td>MemoryType</td>
+    <td>0..*</td>
+  </tr>
+  <tr>
+    <td>\ref element_board_algorithm "algorithm"</td>
+    <td>Specify Flash programming algorithms for memory provided by the board.</td>
+    <td>AlgorithmType</td>
+    <td>0..*</td>
   </tr>
 </table>
 
@@ -615,6 +635,202 @@ The table lists values to identify a specific type of documentation for developm
     <td>All other documentation.</td>
   </tr>
 </table>
+
+\section element_board_memory /package/boards/board/memory
+
+This element specifies memory regions that boards may add. Memory types are predefined and can be selected.
+
+\b Example
+\todo example needs update
+\code
+</package>
+  ...
+  <boards>
+    <board vendor="MyVendor" name="Board-1">
+      <memory name="SRAM-EX" access="rwx" start="0x40000000" size="0x200000"/>
+      <algorithm name="Flash/SARM-EX.flm" start="0x40000000" size="0x200000" style="Keil"/>
+    </board>
+  </boards>
+  ...
+</package>
+\endcode
+
+\n
+
+<table class="cmtable" summary="Element: memory">
+  <tr>
+    <th>Parents</th>
+    <th colspan="3">Element Chain</th>
+  </tr>
+  <tr>
+    <td>\ref element_board "board"</td>
+    <td colspan="3">\ref element_board</td>
+  </tr>
+  <tr>
+    <th>Attributes</th>
+    <th>Description</th>
+    <th>Type</th>
+    <th>Use</th>
+  </tr>
+  <tr>
+    <td>Pname</td>
+    <td>Processor identifier. This attribute <b>is for boards that use devices with multiple processors</b>. 
+        Only alphabetical characters, decimal digits, '-' and '_' are allowed. </td>
+    <td>RestrictedString</td>
+    <td>optional</td>
+  </tr>
+  <tr>
+    <td>name</td>
+    <td>
+      <p>Unique name of the memory to be used in conjunction with <em>access</em>.</p>
+      <p>If a memory with the same name is already defined in a parent scope, the parent one is extended/overwritten.</p>
+      <p>Backward compatibility: If no 'name' attribute is given but 'id' attribute
+      is still present, the given 'id' attribute is used as the 'name'.</p>
+    </td>
+    <td>xs:string</td>
+    <td>optional</td>
+  </tr>
+  <tr>
+    <td>access</td>
+    <td>Access permission of the memory. See \ref MemoryAccessTypeString for details.</td>
+    <td>\ref MemoryAccessTypeString "MemoryAccessTypeString"</td>
+    <td>optional</td>
+  </tr>
+  <tr>
+    <td>start</td>
+    <td>Base address of the memory using a hexadecimal value.</td>
+    <td>NonNegativeInteger</td>
+    <td>required</td>
+  </tr>
+  <tr>
+    <td>size</td>
+    <td>Size of the memory in bytes using a hexadecimal value.</td>
+    <td>NonNegativeInteger</td>
+    <td>required</td>
+  </tr>
+  <tr>
+    <td>default</td>
+    <td>
+      <p>Indicates a general purpose memory region, that does not require any special considerations (access speed, remapping, protection, etc.).</p>
+      <p>If \token{true}, then the memory region will be used by the linker.</p>
+      <p>Default value is \token{false}.</p>
+    </td>
+    <td>xs:boolean</td>
+    <td>optional</td>
+  </tr>
+  <tr>
+    <td>startup</td>
+    <td>If \token{true}, the startup code of the application will be placed into this memory region. Default value is \token{false}.</td>
+    <td>xs:boolean</td>
+    <td>optional</td>
+  </tr>
+  <tr>
+    <td>uninit</td>
+    <td>
+      <p>If \token{true}, the memory region shall be kept uninitialized (i.e. keep the memory state as is).</p>
+      <p>Default value is \token{false}.</p>
+    </td>
+    <td>xs:boolean</td>
+    <td>optional</td>
+  </tr>
+  <tr>
+    <td>alias</td>
+    <td>
+      Reference to another memory (by it's 'name' attribute) which shares the same physical memory. Some physical
+      memory is made accessible via different addresses, for example, cached vs. non-cached accesses. This
+      avoids the impression that the device has twice as much memory available.
+    </td>
+    <td>xs:string</td>
+    <td>optional</td>
+  </tr>
+</table>
+
+\section element_board_algorithm /package/boards/board/algorithm
+
+Specify Flash programming algorithms with the address range and its size for board-specific memory.  An algorithm with 
+\<default> set to \token{true} gets configured automatically to the download options of the project.
+
+<table class="cmtable" summary="Type: AlgorithmType">
+  <tr>
+    <th>Parents</th>
+    <th colspan="3">Element Chain</th>
+  </tr>
+  <tr>
+    <td>\ref element_board "board"</td>
+    <td colspan="3">\ref element_board</td>
+  </tr>
+  <tr>
+    <th>Attributes</th>
+    <th>Description</th>
+    <th>Type</th>
+    <th>Use</th>
+  </tr>
+  <tr>
+    <td>Pname</td>
+    <td>Processor identifier. This attribute <b>is for boards that use devices with multiple processors</b>. 
+        Only alphabetical characters, decimal digits, '-' and '_' are allowed. </td>
+    <td>RestrictedString</td>
+    <td>optional</td>
+  </tr>
+  <tr>
+    <td>name</td>
+    <td>Flash Programming Algorithm file including the path, which is relative to the root folder of the \ref cp_SWComponents "Software Pack".</td>
+    <td>xs:string</td>
+    <td>required</td>
+  </tr>
+  <tr>
+    <td>start</td>
+    <td>Base address for the Flash programming algorithm.</td>
+    <td>NonNegativeInteger</td>
+    <td>required</td>
+  </tr>
+  <tr>
+    <td>size</td>
+    <td>Size covered by the Flash programming algorithm. End address = start + size - 1</td>
+    <td>NonNegativeInteger</td>
+    <td>required</td>
+  </tr>
+   <tr>
+    <td>RAMstart</td>
+    <td>Base address for the RAM where the Flash programming algorithm will be executed from. If
+    specified, the \ref element_memory "memory" element does not require a \c default attribute.</td>
+    <td>NonNegativeInteger</td>
+    <td>optional</td>
+  </tr>
+  <tr>
+    <td>RAMsize</td>
+    <td>Maximum size of RAM available for the execution of the Flash programming algorithm. 
+    End address = start + size - 1 is used for the Stack. If specified, the \ref element_memory 
+    "memory" element does not require a \c default attribute.</td>
+    <td>NonNegativeInteger</td>
+    <td>optional</td>
+  </tr>
+  <tr>
+    <td>default</td>
+    <td>If \token{true}, then this is the default Flash programming algorithm that gets configured
+    in a project. If not specified or set to \token{false}, then the Flash programming algorithm can
+    be configured on a lower level. However, the Flash programming algorithm of a project can be
+    changed manually at any time during development.
+    </td>
+    <td>xs:boolean</td>
+    <td>optional</td>
+  </tr>
+    <tr>
+    <td>style</td>
+    <td>[Version 1.4.0] Today, different toolchains support different styles of incompatible flash
+    programming algorithms. The attribute specifies the style of the specified flash programming 
+    algorithm. For backward compatibility the default value is \token{Keil}. The aim is to converge to
+    the <em>CMSIS</em> style.
+    </td>
+    <td>\ref AlgorithmStyleEnum "AlgorithmStyleEnum"</td>
+    <td>optional</td>
+  </tr>
+
+</table>
+
+
+
+
 
 <p>&nbsp;</p>
 */

--- a/doxygen/src/conditions_schema.txt
+++ b/doxygen/src/conditions_schema.txt
@@ -338,6 +338,24 @@ A \ref element_condition "condition" becomes \token{true} when:
     <td>optional</td>
   </tr>
   <tr>
+    <td>Bvendor<b>*</b></td>
+    <td>Specifies a board vendor name that refers to a \<board\> element in a PDSC file.</td>
+    <td>xs:string</td>
+    <td>optional</td>
+  </tr>
+  <tr>
+    <td>Bname<b>*</b></td>
+    <td>Specifies a board name that refers to a \<board\> element in a PDSC file.</td>
+    <td>xs:string</td>
+    <td>optional</td>
+  </tr>
+  <tr>
+    <td>Brevision<b>*</b></td>
+    <td>Specifies a board revision that refers to a \<board\> element in a PDSC file.</td>
+    <td>xs:string</td>
+    <td>optional</td>
+  </tr>
+  <tr>
     <td>Tcompiler</td>
     <td>Specifies a compiler toolchain (ARMCC, GCC, IAR, Tasking, ...). Use predefined values as listed in table \ref CompilerEnumType "Compiler Types".</td>
     <td>\ref CompilerEnumType</td>
@@ -369,11 +387,12 @@ A \ref element_condition "condition" becomes \token{true} when:
        - [abc] matches any character in the set (a,b,c)
    
 <b>**)</b> These attributes must not be used in conditions because
-           - 'Dfamily' and 'DsubFamily' turn out to be volatile.
+           - 'Dfamily' and 'DsubFamily' turn out to be volatile, meaning that silicon vendors have a trend to change the grouping of devices.
            - conditions shall only filter for selectable devices. 'Dvariant'effectively is just an alias for 'Dname'. 
              Once a \<variant> tag exists, the \<device> tag no longer represents a selectable device.
    
 <p>&nbsp;</p>
+
 
 \anchor CompilerEnumType <b>Table: Compiler Types</b>
 

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -1716,7 +1716,7 @@ The table lists identifiers for memory types.
 \anchor MemoryAccessTypeString <b>Table: Memory Access Attribute String</b>
 
 The table lists the letters and their meaning for use in the access attribute string. The values can be used in:
- - \ref element_memory
+ - \ref element_memory, \ref element_board_memory
 
 <table class="cmtable" summary="Memory Access Permission Attributes">
   <tr>
@@ -2308,7 +2308,7 @@ Contact cmsis@arm.com to ask for an extension. These values can be used in the e
 \anchor AlgorithmStyleEnum <b>Table: Algorithm Styles</b>
 
 The table lists the predefined Flash algorithm style. These values can be used in:
- - \ref element_algorithm
+ - \ref element_algorithm, \ref element_board_algorithm
 
 <table class="cmtable" summary="Enumeration: AlgorithmStyleEnum">
   <tr>


### PR DESCRIPTION
     - added 'uuid' to boards element to indicate a 128-bit universal ID in the debug firmware of the board
     - added 'memory' and 'algorithm' child elements to the boards element to describe board-specific memory
     - added 'Bvendor', 'Bname', 'Brevision' attribute to conditions element to allow board specific filtering.