### PR TITLE
Document $G variable for <generator> variables

### DIFF
--- a/doxygen/src/generators_schema.txt
+++ b/doxygen/src/generators_schema.txt
@@ -155,6 +155,14 @@ Grouping element for \b generators. Only one such group can exist in a Pack.
     <td>$D</th>
     <td>Name of the device configured in the current project</th>
   </tr>
+  <tr>
+    <td>$B</th>
+    <td>Name of the board configured in the current project</th>
+  </tr>
+  <tr>
+    <td>$G</th>
+    <td>Absolute PATH to the generator input file describing the project and component context</th>
+  </tr>
  </table>
 <p>&nbsp;</p>
 <hr>


### PR DESCRIPTION
This variable expands to the absolute path of the generator input file
used to describe the current generator context

Add missing documentation for $B for boardName

Contributed by STMicroelectronics

Signed-off-by: Samuel HULTGREN <samuel.hultgren@st.com>

Fixes https://github.com/Open-CMSIS-Pack/devtools/issues/433