### PR TITLE
feat: add visibility attribute at component level

### DIFF
--- a/doxygen/pack.dxy
+++ b/doxygen/pack.dxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Open-CMSIS-Pack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Version 1.7.12"
+PROJECT_NUMBER         = "Version 1.7.13"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -84,6 +84,12 @@ Pack\\Tutorials | Tutorials for \ref cp_Packs "Creating Packs" |
     <th>Description</th>
   </tr>
   <tr>
+    <td>1.7.13</td>
+    <td>
+     - added visibility atrribute for components as suggested by NXP and STMicroelectronics.
+    </td>
+  </tr>
+  <tr>
     <td>1.7.12</td>
     <td>
      - added 'Linkedsemi' Dvendor ID.

--- a/doxygen/src/components_schema.txt
+++ b/doxygen/src/components_schema.txt
@@ -383,7 +383,7 @@ Components enclosed in a bundle must not specify any of the following attributes
   <tr>
     <td>licenseSet</td>
 	<td>Reference to the \token{licenseSet} with the given identifier \token{ID} specified in the licenseSets section of the package description.
-	    A licenseSet describes one or more license files which in this case govern all components of this bundle. If the licenseSet is 
+	    A licenseSet describes one or more license files which in this case govern all components of this bundle. If the licenseSet is
         different for different components in the bundle, the licenseSet attribute is required to be assigned on a component level.</td>
 	<td>xs:string</td>
 	<td>optional</td>
@@ -531,6 +531,16 @@ A component describes a collection of files (source, header, configuration, libr
 	<td>Reference to the \token{licenseSet} with the given identifier \token{ID} specified in the licenseSets section of the package description.
 	    A licenseSet describes one or more license files that govern the component.</td>
 	<td>xs:string</td>
+	<td>optional</td>
+  </tr>
+  <tr>
+  <td>visibility</td>
+	<td>This attribute defines a recommendation concerning the behavior the Project Manager tool should apply to decide if a component is shown or hidden at composition stage.
+      The indication can be applied or ignored depending on the current procedure (ex: applied only once conditions resolution has been completed).
+      Predefined values can be used as listed in the table \ref CvisibilityType "Component visibility".
+      This does not change the way the component can be used, it deals only with some rendering recommendations.
+  </td>
+	<td>\ref CvisibilityType</td>
 	<td>optional</td>
   </tr>
   <tr>

--- a/doxygen/src/pdsc_format.txt
+++ b/doxygen/src/pdsc_format.txt
@@ -1278,4 +1278,56 @@ The following table lists predefined values for the Component Class <b>Cclass="D
 
 <p>&nbsp;</p>
 
+\anchor CvisibilityType <b>Table: Component visibility</b>
+
+Component visibility values are recommendations from the pack designer that the Project Manager tool can use to make display choices (ex: when it is required to optimize the display of the project composition).
+Typically, it can be used by tools to remove some components from the screen, so that it is easier to get the global project picture.
+The attribute is indicative.
+These recommendations are applicable, but with a lower priority than the end-user's choices and the tools' needs.
+For instance:
+- If the end-user defines a display criterion (like filtering all Board Support components), then the end-user criterion takes precedence over this visibility attribute.
+- If the tool needs a user input to resolve a condition related to a component, the visibility recommendation can be bypassed.
+
+\b Example:
+\code
+  <... visibility="Maskable" ...>
+\endcode
+
+Component A, a Device component, has visibility set to "Maskable".
+1. This Component A is shown in the list of available components.
+2. The end-user adds component A to his project.
+3. The end-user enters a “simplified UI” view of the tool: component A becomes hidden.
+4. The end-user applies a display filter of his choice : “show all Device class components”.
+5. Component A becomes visible, even in the simplified UI view.
+
+<p>&nbsp;</p>
+
+The table lists predefined visibility values.
+<table class="cmtable" summary="Predefined visibility names">
+  <tr>
+    <th>Cclass=</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td class="XML-Token">Always (default)</td>
+	<td>This component must always be presented to the end-user.
+      Overriden by end-user settings if any.
+  </td>
+  </tr>
+  <tr>
+    <td class="XML-Token">Undesirable</td>
+	<td>Presenting this component to the end-user should be avoided, even when it is added to the project by dependency resolution.
+      Overriden by end-user settings if any, or by tool's needs (ex: asking user decision about this component).
+  </td>
+  </tr>
+  <tr>
+    <td class="XML-Token">Maskable</td>
+    <td>Showing or hiding the component is the tool’s choice based on its current context.
+        This recommendation is overriden by end-user settings if any.
+    </td>
+  </tr>
+</table>
+
+<p>&nbsp;</p>
+
 */

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -17,13 +17,15 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-  $Date:        09. Aug 2022
-  $Revision:    1.7.12
+  $Date:        09. Sep 2022
+  $Revision:    1.7.13
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
-  SchemaVersion=1.7.12
+  SchemaVersion=1.7.13
 
+  09. Sep 2022: v1.7.13
+   - added visibility description for components as suggested by NXP and STMicroelectronics
   09. Aug 2022: v1.7.12
    - added 'Linkedsemi' Dvendor entry
   19. July 2022: v1.7.11
@@ -161,7 +163,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.12">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.13">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">
@@ -1832,6 +1834,15 @@
     <xs:attribute name="value" type="xs:string" use="optional" />
   </xs:complexType>
 
+  <!-- visibility Type -->
+  <xs:simpleType name="CvisibilityType">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="0" />
+      <xs:maxLength value="32" />
+      <xs:pattern value="([a-zA-Z0-9\S]*)?"></xs:pattern>
+    </xs:restriction>
+  </xs:simpleType>
+
   <!-- package description root point -->
   <xs:element name="package" nillable="true">
     <xs:complexType>
@@ -1980,6 +1991,8 @@
                   <xs:attribute name="isDefaultVariant" type="xs:boolean" use="optional" />
                   <!-- associates all components of the bundle with a licenseSet using a licenseSet ID which is unique within the pack scope (added in 1.7.9) -->
                   <xs:attribute name="licenseSet" type="xs:string" use="optional"/>
+                  <!-- visibility attribute : recommendation for whowing/hiding this component when displaying the project composition-->
+                  <xs:attribute name="visibility" type="CvisibilityType" use="optional"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="component" minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
Open-CMSIS-Pack issue #112
Some components may not be presented at composition stage to avoid confusing the end-user. Nevertheless, the end-user must still be able to define his own filtering choices. Hence, the visibility attribute is a hint/recommendation from the pack designer.