### PR TITLE
Add projectpath inside file element.

### DIFF
--- a/doxygen/pack.dxy
+++ b/doxygen/pack.dxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Open-CMSIS-Pack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Version 1.7.14"
+PROJECT_NUMBER         = "Version 1.7.15"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -84,6 +84,12 @@ Pack\\Tutorials | Tutorials for \ref cp_Packs "Creating Packs" |
     <th>Description</th>
   </tr>
   <tr>
+    <td>1.7.15</td>
+    <td>
+     - added 'projectpath' attribute which can be used by IDE to construct file location folder in IDE project explorer view of workspace.
+    </td>
+  </tr>
+  <tr>
     <td>1.7.14</td>
     <td>
      - added 'changelog' element providing references to change log files by component, api and bundle elements
@@ -96,7 +102,7 @@ Pack\\Tutorials | Tutorials for \ref cp_Packs "Creating Packs" |
     <td>
      - added VirtualHW as a new board type in support of the Arm Virtual Hardware initiative
      - added \<parts> element and its child elements for describing and packaging the parts (devices other than the MCU).
-     - added \<mountedPart> element, as child element of the \<board> element, for describing the parts (devices other than the MCU) 
+     - added \<mountedPart> element, as child element of the \<board> element, for describing the parts (devices other than the MCU)
        mounted on the development board.
     </td>
   </tr>

--- a/doxygen/src/components_schema.txt
+++ b/doxygen/src/components_schema.txt
@@ -843,6 +843,15 @@ The file purpose is defined through the <b>category</b> attribute. The <b>name</
     <td>xs:boolean</td>
     <td>optional</td>
   </tr>
+    <tr>
+    <td>projectpath</td>
+    <td>View location path for a file of component inside IDE project explorer view. When a component is selected into a project, IDE
+        can use it to construct component file view location path inside the IDE project explorer view. It gives component files a better
+        organization view instead of just flat placing them in the project explorer. IDE can also directly ignore this attribute,
+        then all files of the component will be flat placed inside the project explorer view under Cclass.</td>
+    <td>xs:string</td>
+    <td>optional</td>
+  </tr>
 </table>
 
 <p>&nbsp;</p>

--- a/doxygen/src/pack_tutorial.txt
+++ b/doxygen/src/pack_tutorial.txt
@@ -241,6 +241,10 @@ Optionally, every file may have the following attributes:
   component version is used.
 - \c public: Set publishing permissions for the documentation. If \em <b>true</b>, the documentation can be extracted and
   published on a web page.
+- \c projectpath: View location path for a file of component inside IDE project explorer view. When a component is selected into
+  a project, IDE can use it to construct component file view location path inside the IDE project explorer view. It gives component
+  files a better organization view instead of just flat placing them in the project explorer. IDE can also directly ignore this
+  attribute, then all files of the component will be flat placed inside the project explorer view under Cclass.
 
 
 \subsection cp_Conditions Conditions

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -17,13 +17,15 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-  $Date:        10. Oct 2022
-  $Revision:    1.7.14
+  $Date:        24. Oct 2022
+  $Revision:    1.7.15
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
-  SchemaVersion=1.7.14
+  SchemaVersion=1.7.15
 
+  24. Oct 2022: v1.7.15
+   - added 'projectpath' attribute which can be used by IDE to construct file location folder in IDE project explorer view of workspace.
   10. Oct 2022: v1.7.14
    - added 'changelog' element providing references to change log files by component, api and bundle elements
    - added 'Puya' Dvendor entry
@@ -169,7 +171,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.14">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.15">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">
@@ -1545,6 +1547,9 @@
     <!-- if true, the vendor gives permission for this file being extracted from the pack and displayed on a web-page -->
     <!-- links to web pages are assumed public -->
     <xs:attribute name="public" type="xs:boolean" use="optional" default="false" />
+    <!-- project path:  View location path for a file of component inside IDE project explorer view. -->
+    <!-- if not provided, all files of the component will be flat placed inside the IDE project explorer view under Cclass of component-->
+    <xs:attribute name="projectpath" type="xs:string" use="optional" />
   </xs:complexType>
 
   <!-- some strings are used to construct filenames (e.g. package name). Such names can contain only subset of characters


### PR DESCRIPTION
projectpath is a folder path for a file. IDE can use it to construct file location folder in IDE project explorer view of workspace.