### PR TITLE
Clarify numeric enums

### DIFF
--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -2615,12 +2615,12 @@ The values can be used in the elements:
     <th>Description</th>
   </tr>
   <tr>
-    <td class="XML-Token">MPU</td>
-    <td>Memory Protection Unit is present</td>
-  </tr>
-  <tr>
     <td class="XML-Token">NO_MPU</td>
     <td>No Memory Protection Unit is present</td>
+  </tr>
+  <tr>
+    <td class="XML-Token">MPU</td>
+    <td>Memory Protection Unit is present</td>
   </tr>
 </table>
 
@@ -2641,12 +2641,12 @@ The values can be used in the elements:
     <th>Description</th>
   </tr>
   <tr>
-    <td class="XML-Token">TZ</td>
-    <td>TrustZone is present</td>
-  </tr>
-  <tr>
     <td class="XML-Token">NO_TZ</td>
     <td>No TrustZone is present</td>
+  </tr>
+  <tr>
+    <td class="XML-Token">TZ</td>
+    <td>TrustZone is present</td>
   </tr>
 </table>
 
@@ -2666,12 +2666,12 @@ The values can be used in the elements:
     <th>Description</th>
   </tr>
   <tr>
-    <td class="XML-Token">Secure</td>
-    <td>Application is built to run in secure mode.</td>
-  </tr>
-  <tr>
     <td class="XML-Token">Non-secure</td>
     <td>Application is built to run in non-secure mode.</td>
+  </tr>
+  <tr>
+    <td class="XML-Token">Secure</td>
+    <td>Application is built to run in secure mode.</td>
   </tr>
   <tr>
     <td class="XML-Token">TZ-disabled</td>
@@ -2697,12 +2697,12 @@ The values can be used in the elements:
     <th>Description</th>
   </tr>
   <tr>
-    <td class="XML-Token">DSP</td>
-    <td>DSP instructions supported</td>
-  </tr>
-  <tr>
     <td class="XML-Token">NO_DSP</td>
     <td>No DSP instructions supported</td>
+  </tr>
+  <tr>
+    <td class="XML-Token">DSP</td>
+    <td>DSP instructions supported</td>
   </tr>
 </table>
 

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -1029,12 +1029,12 @@
   <!-- Dfpu enumeration type -->
   <xs:simpleType name="DfpuEnum">
     <xs:restriction base="xs:token">
-      <!-- core has FPU (type of FPU depends on Dcore) -->
-      <xs:enumeration value="FPU" />
-      <xs:enumeration value="1" />
       <!-- core has no FPU -->
       <xs:enumeration value="NO_FPU" />
       <xs:enumeration value="0" />
+      <!-- core has FPU (type of FPU depends on Dcore) -->
+      <xs:enumeration value="FPU" />
+      <xs:enumeration value="1" />
       <!-- single precision FPU -->
       <xs:enumeration value="SP_FPU" />
       <!-- double precision FPU -->
@@ -1047,12 +1047,12 @@
   <!-- Dmpu enumeration type -->
   <xs:simpleType name="DmpuEnum">
     <xs:restriction base="xs:token">
-      <!-- MPU -->
-      <xs:enumeration value="MPU" />
-      <xs:enumeration value="1" />
       <!-- no MPU -->
       <xs:enumeration value="NO_MPU" />
       <xs:enumeration value="0" />
+      <!-- MPU -->
+      <xs:enumeration value="MPU" />
+      <xs:enumeration value="1" />
       <!-- any -->
       <xs:enumeration value="*" />
     </xs:restriction>
@@ -1061,12 +1061,12 @@
   <!-- Dtz TrustZone enumeration type -->
   <xs:simpleType name="DtzEnum">
     <xs:restriction base="xs:token">
-      <!-- TZ -->
-      <xs:enumeration value="TZ" />
-      <xs:enumeration value="1" />
       <!-- no TZ -->
       <xs:enumeration value="NO_TZ" />
       <xs:enumeration value="0" />
+      <!-- TZ -->
+      <xs:enumeration value="TZ" />
+      <xs:enumeration value="1" />
       <!-- any -->
       <xs:enumeration value="*" />
     </xs:restriction>
@@ -1092,12 +1092,12 @@
   <!-- Ddsp DSP extensions enumeration type -->
   <xs:simpleType name="DdspEnum">
     <xs:restriction base="xs:token">
-      <!-- DSP -->
-      <xs:enumeration value="DSP" />
-      <xs:enumeration value="1" />
       <!-- no DSP -->
       <xs:enumeration value="NO_DSP" />
       <xs:enumeration value="0" />
+      <!-- DSP -->
+      <xs:enumeration value="DSP" />
+      <xs:enumeration value="1" />
       <!-- any -->
       <xs:enumeration value="*" />
     </xs:restriction>

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -1047,10 +1047,13 @@
   <!-- Dmpu enumeration type -->
   <xs:simpleType name="DmpuEnum">
     <xs:restriction base="xs:token">
+      <!-- MPU -->
       <xs:enumeration value="MPU" />
+      <xs:enumeration value="1" />
+      <!-- no MPU -->
       <xs:enumeration value="NO_MPU" />
       <xs:enumeration value="0" />
-      <xs:enumeration value="1" />
+      <!-- any -->
       <xs:enumeration value="*" />
     </xs:restriction>
   </xs:simpleType>
@@ -1058,10 +1061,13 @@
   <!-- Dtz TrustZone enumeration type -->
   <xs:simpleType name="DtzEnum">
     <xs:restriction base="xs:token">
+      <!-- TZ -->
       <xs:enumeration value="TZ" />
-      <xs:enumeration value="NO_TZ" />
       <xs:enumeration value="1" />
+      <!-- no TZ -->
+      <xs:enumeration value="NO_TZ" />
       <xs:enumeration value="0" />
+      <!-- any -->
       <xs:enumeration value="*" />
     </xs:restriction>
   </xs:simpleType>
@@ -1069,12 +1075,16 @@
   <!-- Dsecure enumeration type -->
   <xs:simpleType name="DsecureEnum">
     <xs:restriction base="xs:token">
+      <!-- Non Secure -->
       <xs:enumeration value="Non-secure" />
-      <xs:enumeration value="Secure" />
-      <xs:enumeration value="TZ-disabled" />
       <xs:enumeration value="0" />
+      <!-- Secure -->
+      <xs:enumeration value="Secure" />
       <xs:enumeration value="1" />
+      <!-- TZ disabled -->
+      <xs:enumeration value="TZ-disabled" />
       <xs:enumeration value="2" />
+      <!-- any -->
       <xs:enumeration value="*" />
     </xs:restriction>
   </xs:simpleType>
@@ -1082,10 +1092,13 @@
   <!-- Ddsp DSP extensions enumeration type -->
   <xs:simpleType name="DdspEnum">
     <xs:restriction base="xs:token">
+      <!-- DSP -->
       <xs:enumeration value="DSP" />
-      <xs:enumeration value="NO_DSP" />
       <xs:enumeration value="1" />
+      <!-- no DSP -->
+      <xs:enumeration value="NO_DSP" />
       <xs:enumeration value="0" />
+      <!-- any -->
       <xs:enumeration value="*" />
     </xs:restriction>
   </xs:simpleType>


### PR DESCRIPTION
Poor mans documentation of how numeric enums map to string values for `Dmpu` and friends.

While it logically makes sense that `0` is false and `1` is true, the order of table rows in the docs could indicate otherwise:
- [DfpuEnum starts with NO_FPU](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/pdsc_family_pg.html#DfpuEnum), reader might ask: does it mean `0` is `NO_FPU`
- [DmpuEnum starts with MPU](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/pdsc_family_pg.html#DmpuEnum), reader might ask: does it mean `0` is `MPU`?

From what I gather those numeric enums are deprecated. Is it worth listing those in doxygen tables anyway? I'd mark them deprecated. 
For now, I only reordered definitions in tables, so that `0` value matches first row. 