### PR TITLE
Vendor name should allow '-' char as well

### DIFF
--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -317,7 +317,7 @@
     <xs:restriction base="xs:string">
       <xs:minLength value="2" />
       <xs:maxLength value="32" />
-      <xs:pattern value="[A-Za-z0-9][A-Za-z0-9\s]+" />
+      <xs:pattern value="[A-Za-z0-9][A-Za-z0-9\-\s]+" />
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
Vendor names with '-' char should be allowed
For e.g 
M`DK-Packs`, `ARM-Packs`