### PR TITLE
Specify that URL to a website is allowed in book element

### DIFF
--- a/doxygen/pack.dxy
+++ b/doxygen/pack.dxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Open-CMSIS-Pack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Version 1.7.22"
+PROJECT_NUMBER         = "Version 1.7.23"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -84,6 +84,13 @@ Pack\\Tutorials | Tutorials for \ref cp_Packs "Creating Packs" |
     <th>Description</th>
   </tr>
   <tr>
+    <td>1.7.23</td>
+    <td>
+     - specified that url to a website in book element is allowed
+     - aligned \<book> element occurrence in \ref element_board "board" table to XSD schema
+    </td>
+  </tr>
+  <tr>
     <td>1.7.22</td>
     <td>
      - added 'Hvendor' and 'Hname' as attributes of the \ref element_accept "accept", \ref element_require "require" and \ref element_deny "deny" elements

--- a/doxygen/src/boards_schema.txt
+++ b/doxygen/src/boards_schema.txt
@@ -202,7 +202,7 @@ This element provides information to specify the \ref createPackBoard "Board Sup
     <td>\ref element_board_book "book"</td>
 	<td>Describes the documentation files (user manuals, schematics, etc.). Directory and file names are case-sensitive.</td>
 	<td>BoardsBookType</td>
-	<td>1..* </td>
+	<td>0..* </td>
   </tr>
   <tr>
     <td>\ref element_board_debugProbe "debugProbe"</td>
@@ -700,10 +700,11 @@ This element specifies an optional on-board debug probe.
 
 \section element_board_book /package/boards/board/book
 
-The element provides information about documentation parts related to a development board. At least one book must be defined.
+The element provides information about documentation parts related to a development board.
 
 \b Example
 \code
+<book category="overview" name="http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/LN1199/PF259090" title="32F429IDISCOVERY Web Page"/>
 <book category="setup" name="Documents/UM1662.pdf" title="Getting Started"/>
 \endcode
 <p>&nbsp;</p>		
@@ -731,7 +732,7 @@ The element provides information about documentation parts related to a developm
   </tr>
   <tr>
     <td>name</td>
-	<td>Is the name of the document (including the path within the Pack).</td>
+	<td>Is the name of the document (including the path within the Pack). The link to a document on an external web site is also allowed.</td>
 	<td>xs:string</td>
 	<td>optional</td>
   </tr>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -1029,7 +1029,7 @@ size of all previous \<block> and \<gap> elements of this flash device.
 \section element_book /package/devices/family/.../book
 
 Specifies documents related to a device or a part. Books can be entered on various levels.
-The book element contains the location, filename, and extension of the file. The title is used for display purposes.
+The book element contains the location, the name and the extension of the file. The link to a document on an external web site is also allowed. The title is used for display purposes.
 
 \b Example
 \code
@@ -1102,7 +1102,7 @@ The book element contains the location, filename, and extension of the file. The
   <tr>
     <td>name</td>
     <td>File name of the document including the extension. The document path is relative to the package base folder. 
-        Directory/file names are case-sensitive.</td>
+        Directory/file names are case-sensitive. The link to a document on an external web site is also allowed.</td>
     <td>xs:string</td>
     <td>required</td>
   </tr>

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -17,13 +17,16 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-  $Date:        12. Apr 2023
-  $Revision:    1.7.22
+  $Date:        27. Apr 2023
+  $Revision:    1.7.23
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
-  SchemaVersion=1.7.22
+  SchemaVersion=1.7.23
 
+  27. Apr 2023: v1.7.23
+   - specified that url to a website in book element is allowed
+   - aligned /package/boards/board/book element occurrence in documentation to XSD schema
   12. Apr 2023: v1.7.22
    - added Hvendor and Hname as attributes of the accept, require and deny elements
    - redefined Hvendor as xs:string
@@ -191,7 +194,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.22">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.23">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">
@@ -738,7 +741,7 @@
   <xs:complexType name="BookType">
     <!-- Pname identifies the processor this setting belongs to -->
     <xs:attribute name="Pname" type="RestrictedString" />
-    <!-- name specifies the path and filename of the document -->
+    <!-- name specifies either the path in the package and the filename of the document or the link to an external web site -->
     <xs:attribute name="name" type="xs:string" use="required" />
     <!-- title specifies the string displayed for this document -->
     <xs:attribute name="title" type="xs:string" use="required" />
@@ -1468,6 +1471,7 @@
 
   <xs:complexType name="BoardsBookType">
     <xs:attribute name="category" type="BoardBookCategoryEnum" />
+    <!-- name specifies either the path in the package and the filename of the document or the link to an external web site -->
     <xs:attribute name="name" type="xs:string" />
     <xs:attribute name="title" type="xs:string" />
     <!-- if true, the vendor gives permission for this file being extracted from the pack and displayed on a web-page -->


### PR DESCRIPTION
Aligned also \<book> element occurrence in "package/boards/board" table to XSD schema. Commit related to issue #220.