### PR TITLE
Corrected assumption around "public"

### DIFF
--- a/doxygen/src/pdsc_format.txt
+++ b/doxygen/src/pdsc_format.txt
@@ -1132,7 +1132,7 @@ software components in projects. Reserved characters are:
     <td>public</td>
     <td>Set publishing permissions for the documentation. If \tagem{public} is \token{true}, then the vendor gives permission
         to extract the documentation from the pack and publish it on a web-page. Links to web pages are assumed to be public.
-        The default value is \token{false}.</td>
+        The default value is \token{true} (this is also the basic assumption if the tag is missing).</td>
     <td>xs:boolean</td>
     <td>optional</td>
   </tr>

--- a/doxygen/src/pdsc_format.txt
+++ b/doxygen/src/pdsc_format.txt
@@ -1438,7 +1438,7 @@ It is recommended to use an already agreed part-taxonomy for interchangeable par
     <td>public</td>
     <td>Set publishing permissions for the documentation. If \tagem{public} is \token{true}, then the vendor gives permission
         to extract the documentation from the pack and publish it on a web-page. Links to web pages are assumed to be public.
-        The default value is \token{false}.</td>
+        The default value is \token{true} (this is also the basic assumption if the tag is missing).</td>
     <td>xs:boolean</td>
     <td>optional</td>
   </tr>


### PR DESCRIPTION
As we have introduced this tag late in the process, we must assume that non-tagged elements are true and you need to be actively stating that something is "false" = private.