### PR TITLE
Clarify condition Cversion implicit range and bundle Cversion redefinition by components

### DIFF
--- a/doxygen/src/components_schema.txt
+++ b/doxygen/src/components_schema.txt
@@ -114,7 +114,7 @@ The attributes \b Cvendor, \b Cclass, \b Cbundle as well as \b Cversion are inhe
 Only the \b Cversion attribute can be redefined in the \b component elements.
 
 Components of the same \b Cclass belonging to a different \b Cbundle shall not be selected concurrently. In this way bundles ensure
-interoperability across multiple ocmponents and restrict the max and match of components within a \b Cclass.
+interoperability across multiple components and restrict the mix and match of components within a \b Cclass.
 
 An example of a <b>bundle</b> is shown in the \ref cp_BundleExample section where the bundle is used to deliver board
 support files for a certain development platform.

--- a/doxygen/src/components_schema.txt
+++ b/doxygen/src/components_schema.txt
@@ -7,8 +7,8 @@ A component lists the files that belong to a component and that are relevant for
 individual file may refer to a \ref element_condition "condition" that must resolve to true; if it is false the component
 or file is not applicable in the given context.
 
-Each component must have a class (Cclass=) and/or bundle (Cbundle), a group (Cgroup=), and a version (Cversion=) which is
-used to identify the component. Optionally, a component may have a sub-group (Csub=) and variant (Cvariant=) to add further
+Each component must have a class (Cclass=), a group (Cgroup=), and a version (Cversion=) which is
+used to identify the component. Optionally, a component may have a bundle (Cbundle=), sub-group (Csub=) and variant (Cvariant=) to add further
 categories. A component is identified by the class/bundle, group, sub-group, variant and version information together with
 the vendor specified by the pack. A component vendor must ensure that the combination of class/bundle, group, sub-group,
 version, and variant is unique and not used by multiple components (after evaluating filter
@@ -106,10 +106,15 @@ version, and variant is unique and not used by multiple components (after evalua
 \section Component_Bundle Component Bundle
 
 In case multiple inter-dependent components that belong to the same \b Cclass form part of a solution, these can be grouped
-into a <em>bundle</em>. A <em>bundle</em> specifies identical attributes \b Cclass, \b Cversion and optionally \b Cgroup and
-\b Cvendor for several components. Components within a bundle inherit these attributes set by the bundle and cannot alter
-these attributes. Bundles ensure consistency of attributes across multiple interworking components and restrict the mix and
-match of components within a Cclass from different Software Packs.
+into a <em>bundle</em>. A component bundle is a named set of components that must share identical attributes for \b Cvendor and 
+\b Cclass by introducing the attribute \b Cbundle, which becomes a mandatory part of the component ID. If the attribute \b Cvendor
+is not specified in the \b bundle element, the value is inherited from the pack level \b vendor element.
+
+The attributes \b Cvendor, \b Cclass, \b Cbundle as well as \Cversion are inherited by all \component elements within a \bundle section.
+Only the \b Cversion attribute can be redefined in the \b component elements.
+
+Components of the same \b Cclass belonging to a different \b Cbundle shall not be selected concurrently. In this way bundles ensure
+interoperability across multiple ocmponents and restrict the max and match of components within a \b Cclass.
 
 An example of a <b>bundle</b> is shown in the \ref cp_BundleExample section where the bundle is used to deliver board
 support files for a certain development platform.
@@ -490,7 +495,6 @@ A component describes a collection of files (source, header, configuration, libr
     <td>Cversion</td>
     <td>Defines the version of this component. Is a mandatory part of the component ID.
       The version format is described in \ref VersionType "Version Type".
-      \n \token{Must not be specified for a component within a bundle.}</td>
     <td>\ref VersionType "VersionType"</td>
     <td>required</td>
   </tr>

--- a/doxygen/src/components_schema.txt
+++ b/doxygen/src/components_schema.txt
@@ -110,7 +110,7 @@ into a <em>bundle</em>. A component bundle is a named set of components that mus
 \b Cclass by introducing the attribute \b Cbundle, which becomes a mandatory part of the component ID. If the attribute \b Cvendor
 is not specified in the \b bundle element, the value is inherited from the pack level \b vendor element.
 
-The attributes \b Cvendor, \b Cclass, \b Cbundle as well as \Cversion are inherited by all \component elements within a \bundle section.
+The attributes \b Cvendor, \b Cclass, \b Cbundle as well as \b Cversion are inherited by all \b component elements within a \b bundle section.
 Only the \b Cversion attribute can be redefined in the \b component elements.
 
 Components of the same \b Cclass belonging to a different \b Cbundle shall not be selected concurrently. In this way bundles ensure

--- a/doxygen/src/conditions_schema.txt
+++ b/doxygen/src/conditions_schema.txt
@@ -314,23 +314,25 @@ A \ref element_condition "condition" becomes \token{true} when:
   </tr>
   <tr>
     <td>Cversion</td>
-    <td>Specifies a software component version.
-       - <b>require Cversion:</b>condition is true if version of component is equal or higher than requested.
+    <td>Specifies a software component's version.
+       - <b>require Cversion:</b>condition is true if version of component is equal or higher than requested and compatible.
+         According to <a href="https://semver.org/#spec-item-8"><b>SemanticVersioning</b></a> compatibility requires the <b>major version</b> to remain unchanged.
        - <b>deny Cversion:</b> condition is true if version of component is lower than requested.
        - Version ranges are specified with <em>min_version</em><b>:</b><em>max_version</em>. The condition is true if the version of the component is equal or higher than
-         <em>min_version</em> and lower or equal than <em>max_version</em>. If <em>min_version</em> and <em>max_version</em> are equal the version must match.
-         For more information refer to \ref VersionType "Version Type".</td>
+         <em>min_version</em> and lower or equal than <em>max_version</em>. If <em>min_version</em> and <em>max_version</em> are equal the version must match exactly.
+       Note: Specifying the <em>min_version</em> e.g <em>Cversion="4.1.0"</em> is identical to the version range <em>Cversion="4.1.0:5.0.0-0"</em>.       
     <td>\ref VersionType</td>
     <td>optional</td>
   </tr>
   <tr>
     <td>Capiversion</td>
     <td>Specifies an API version.
-       - <b>require Capiversion:</b>condition is true if version of API is equal or higher than requested.
+       - <b>require Capiversion:</b>condition is true if version of API is equal or higher than requested and compatible.
+         According to <a href="https://semver.org/#spec-item-8"><b>SemanticVersioning</b></a> compatibility requires the <b>major version</b> to remain unchanged.
        - <b>deny Capiversion:</b> condition is true if version of API is lower than requested.
        - Version ranges are specified with <em>min_version</em><b>:</b><em>max_version</em>. The condition is true if the version of the API is equal or higher than
-         <em>min_version</em> and lower or equal than <em>max_version</em>. If <em>min_version</em> and <em>max_version</em> are equal the version must match.
-         For more information refer to \ref VersionType "Version Type".</td>
+         <em>min_version</em> and lower or equal than <em>max_version</em>. If <em>min_version</em> and <em>max_version</em> are equal the version must match exactly.
+       Note: Specifying the <em>min_version</em> e.g <em>Capiversion="4.1.0"</em> is identical to the version range <em>Capiversion="4.1.0:5.0.0-0"</em>.       
     <td>\ref VersionType</td>
     <td>optional</td>
   </tr>

--- a/doxygen/src/pack_tutorial.txt
+++ b/doxygen/src/pack_tutorial.txt
@@ -435,9 +435,8 @@ more information.
 
 
 \subsection cp_Bundles Bundles
-A bundle is basically a variant on the \c Cclass level. It specifies the attributes \c Cclass, \c Cversion and optionally
-\c Cgroup and \c Cvendor for a collection of interdependent components. Components within a bundle inherit the attributes
-set by the bundle and must not set these attributes again. Bundles ensure consistency of attributes across multiple
+A bundle is a named set of components, introducing a kind of variant on the \c Cclass level. It specifies the attributes \c Cvendor, \c Cclass and \c Cversion for a collection of interdependent components. Components within a bundle inherit the attributes
+set by the bundle and except for \c Cversion, must not redefine these attributes. Bundles ensure consistency of attributes across multiple
 interworking components and restrict the mix and match of components within a \c Cclass from different solutions.
 In addition to components, a bundle has the mandatory elements \c description and \c doc (for documentation).
 


### PR DESCRIPTION
Clarify that in conditions Cversion and Capiversion specified by minVersion only only resolve to true for compatible versions, meaning for the same major version value as specified in minVersion.
closing #273
closing #274