### PR TITLE
Fix 'BOYAMICRO' vendor value in "DeviceVendorEnum"

### DIFF
--- a/doxygen/pack.dxy
+++ b/doxygen/pack.dxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Open-CMSIS-Pack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Version 1.7.34"
+PROJECT_NUMBER         = "Version 1.7.35"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -84,6 +84,14 @@ Pack\\Tutorials | Tutorials for \ref cp_Packs "Creating Packs" |
     <th>Description</th>
   </tr>
   <tr>
+    <td>1.7.35</td>
+    <td>
+     - made board element optional in example element
+     - added attribute overview to package description element
+     - fixed 'BOYAMICRO' vendor value in \ref DeviceVendorEnum "DeviceVendorEnum"
+    </td>
+  </tr>
+  <tr>
     <td>1.7.34</td>
     <td>
      - added 'Watech:183' to \ref DeviceVendorEnum "DeviceVendorEnum"

--- a/doxygen/src/examples_schema.txt
+++ b/doxygen/src/examples_schema.txt
@@ -139,15 +139,15 @@ treated as a single example.
   </tr>
   <tr>
     <td>\ref element_example_board "board"</td>
-    <td>Complex type providing a reference to a board description using board name and vendor.</td>.
+    <td>Complex type providing a reference to a board description using board name and vendor.</td>
     <td>BoardReferenceType</td>
-    <td>1</td>
+    <td>0..*</td>
   </tr>
   <tr>
     <td>\ref element_example_project "project"</td>
 	<td>Complex type describing the project files for different environments</td>
 	<td>ExampleProjectType</td>
-	<td>1..* </td>
+	<td>1</td>
   </tr>
   <tr>
     <td>\ref element_example_attributes "attributes"</td>

--- a/doxygen/src/pdsc_format.txt
+++ b/doxygen/src/pdsc_format.txt
@@ -480,7 +480,7 @@ This Markdown file is indented for web pages that offer software packs in form o
     <td>overview</td>
     <td>File path, file name, and file extension in the format path/name.extension. The file path is relative to the root directory of the Pack and contains an overview documentation in Markdown format (file extension *.md).</td>
     <td>xs:string</td>
-    <td>required</td>
+    <td>optional</td>
   </tr>
 </table>
 

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -18,16 +18,17 @@
   limitations under the License.
 
 
-  $Date:        18. April 2024
+  $Date:        22. April 2024
   $Revision:    1.7.35
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
   SchemaVersion=1.7.35
 
-  18. Apr 2024: v1.7.35
+  22. Apr 2024: v1.7.35
    - made board element optional in example element
    - add attribute overview to package description element
+   - fix 'BOYAMICRO' vendor value in 'DeviceVendorEnum'
   12. Apr 2024: v1.7.34
 -  - added 'Watech:183' to 'DeviceVendorEnum'
   26. Mar 2024: v1.7.33
@@ -223,7 +224,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.34">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.35">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">
@@ -253,7 +254,7 @@
       <xs:enumeration value="ArteryTek:143" />
       <xs:enumeration value="Atmel:3" />
       <xs:enumeration value="AutoChips:150" />
-      <xs:enumeration value="BOYAMICRO:168" />
+      <xs:enumeration value="BOYAMICRO:182" />
       <xs:enumeration value="BrainChip:168" />
       <xs:enumeration value="Cmsemicon:161" />
       <xs:enumeration value="CSR:118" />


### PR DESCRIPTION
Also:

- Set PACK.xsd version to v1.7.35.
- Aligned documentation to xsd schema in the following points:
  - "overview" attribute of the /package/description set to optional
  - /package/examples/example/board set to 0..*
  - /package/examples/example/project set to 1