### PR TITLE
Align generators/generator/gpdsc description in doc to XSD schema

### DIFF
--- a/doxygen/src/generators_schema.txt
+++ b/doxygen/src/generators_schema.txt
@@ -368,7 +368,7 @@ element can exist in \ref element_generator "\<generator>".
 
 Path and name of the GPDSC that the generator creates and updates. 
 The path is either absolute or relative to the working directory. 
-If no explicit gpdsc file is provided, then a gpdsc file named after the project with extension gpdsc in the working directory is assumed (<project>.gpdsc).
+If no explicit gpdsc file is provided, then a gpdsc file named after the project with extension gpdsc in the working directory is assumed (\<project>.gpdsc).
 Only one such element can exist in \ref element_generator "\<generator>".
 
 \b Example:

--- a/doxygen/src/generators_schema.txt
+++ b/doxygen/src/generators_schema.txt
@@ -253,12 +253,12 @@ generator element must exist.
     <td>0..1</td>
   </tr>
   <tr>
-    <td>gpdsc</td>
+    <td>\ref element_gen_gpdsc "gpdsc"</td>
     <td>Path and name of the GPDSC that the generator creates and updates. The path is either absolute or relative to the
 	    working directory. If no explicit gpdsc file is provided, then a gpdsc file named after the project with extension gpdsc in
 		the working directory is assumed (\c \<project>.gpdsc).
     </td>
-    <td>xs:string</td>
+    <td>GpdscFileType</td>
     <td>0..1</td>
   </tr>
   <tr>
@@ -307,7 +307,7 @@ generator element must exist.
 \section element_gen_select /package/generators/generator/select
 
 This element contains information about the vendor and device the GPDSC file has been generated for. Only one such
-element can exist in \c \<generators>.
+element can exist in \ref element_generator "\<generator>".
 
 \b Example:
 \code
@@ -359,6 +359,49 @@ element can exist in \c \<generators>.
 	<td>Name of the targeted processor of a device with multiple processors. For devices with multiple processors this tag is required.</td>
 	<td>xs:string</td>
 	<td>optional</td>
+  </tr>
+</table>
+<p>&nbsp;</p>
+<hr>
+
+\section element_gen_gpdsc /package/generators/generator/gpdsc
+
+Path and name of the GPDSC that the generator creates and updates. 
+The path is either absolute or relative to the working directory. 
+If no explicit gpdsc file is provided, then a gpdsc file named after the project with extension gpdsc in the working directory is assumed (<project>.gpdsc).
+Only one such element can exist in \ref element_generator "\<generator>".
+
+\b Example:
+\code
+  <generators>
+    <generator id="MyGen">
+      <gpdsc name="$P/RTE/MyGen/myGen.gpdsc"/>
+    </generator>
+  </generators>
+\endcode
+<p>&nbsp;</p>
+
+<table class="cmtable" summary="Element: Generator Gpdsc">
+  <tr>
+    <th>Parent</th>
+    <th colspan="3">Chain</th>
+  </tr>
+  <tr>
+    <td>\ref element_generator "generator"</td>
+    <td colspan="3">\ref element_generator</td>
+  </tr>
+  <tr>
+    <th>Attributes</th>
+    <th>Description</th>
+    <th>Type</th>
+    <th>Use</th>
+  </tr>
+  <tr>
+    <td>name</td>
+	<td>Path and name of the GPDSC that the generator creates and updates.
+	</td>
+	<td>xs:string</td>
+	<td>required</td>
   </tr>
 </table>
 <p>&nbsp;</p>


### PR DESCRIPTION
The `generators/generator/gpdsc` element has `type = xs:string` in the documentation while it has `type = GpdscFileType` in the Pack.xsd schema (with `GpdscFileType` that has an attribute `name = xs:string`).

In this PR I've aligned the description in the documentation to what is defined in the schema.