### PR TITLE
Github-324: Clear DP sticky error bits in 'DebugPortStart' sequence

### DIFF
--- a/doxygen/pack.dxy
+++ b/doxygen/pack.dxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Open-CMSIS-Pack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Version 1.7.37"
+PROJECT_NUMBER         = "Version 1.7.39"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -79,6 +79,12 @@ The following sections provide more information:
     <th>Description</th>
   </tr>
   <tr>
+    <td>1.7.39</td>
+    <td>
+      - modified default 'DebugPortStart' debug sequence to clear DP sticky error bits
+    </td>
+  </tr>
+  <tr>
     <td>1.7.38</td>
     <td>
       - The \ref createPackPublish "pack publishing process" has been rewritten completely

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -463,18 +463,49 @@ Connect to the target debug port and power it up.
   <sequence name="DebugPortStart">
     
     <block>
-      __var SW_DP_ABORT  = 0x0;
-      __var DP_CTRL_STAT = 0x4;
-      __var DP_SELECT    = 0x8;
-      __var powered_down = 0;
+      __var SW_DP_ABORT    = 0x0;
+      __var DP_CTRL_STAT   = 0x4;
+      __var DP_SELECT      = 0x8;
+      __var DP_STICKY_BITS = 0x000000B2;          // DP CTRL/STAT: STICKYORUN | STICKYCMP | STICKYERR | WDATAERR
+      __var JTAG_DP_STICKY_BITS_CLR = 0x00000032; // DP CTRL/STAT: STICKYORUN | STICKYCMP | STICKYERR
+      __var SWD_DP_STICKY_BITS_CLR  = 0x0000001E; // DP ABORT: ORUNERRCLR | WDERRCLR | STKERRCLR | STKCMPCLR
+      __var powered_down   = 0;
+      __var ctrl_stat_val  = 0;
 
       // Switch to DP Register Bank 0
       WriteDP(DP_SELECT, 0x00000000);
     
       // Read DP CTRL/STAT Register and check if CSYSPWRUPACK and CDBGPWRUPACK bits are set
-      powered_down = ((ReadDP(DP_CTRL_STAT) &amp; 0xA0000000) != 0xA0000000);
+      ctrl_stat_val = ReadDP(DP_CTRL_STAT);
+      powered_down = ((ctrl_stat_val &amp; 0xA0000000) != 0xA0000000);
     </block>
     
+    <!-- Check and clear sticky error bits -->
+    <control if="ctrl_stat_val &amp; DP_STICKY_BITS">
+
+      <!-- JTAG specific part -->
+      <control if="(__protocol &amp; 0xFFFF) == 1">
+
+        <block>
+          // Clear JTAG-DP sticky error bits by writing '1', preserve other values
+          WriteDP(DP_CTRL_STAT, ctrl_stat_val | JTAG_DP_STICKY_BITS_CLR);
+        </block>
+
+      </control>
+
+      <!-- SWD specific part -->
+      <control if="(__protocol &amp; 0xFFFF) == 2">
+
+        <block>
+          // Clear SWD-DP sticky error bits by writing to DP ABORT
+          WriteDP(SW_DP_ABORT, SWD_DP_STICKY_BITS_CLR);
+        </block>
+
+      </control>
+
+    </control>
+
+    <!-- Check if DP is powered down and power it up if so -->
     <control if="powered_down">
     
       <block>
@@ -485,18 +516,18 @@ Connect to the target debug port and power it up.
       <!-- Wait for Power-Up Request to be acknowledged -->
       <control while="(ReadDP(DP_CTRL_STAT) &amp; 0xA0000000) != 0xA0000000" timeout="1000000"/>
       
-      <!-- JTAG Specific Part of sequence -->
+      <!-- JTAG specific part -->
       <control if="(__protocol &amp; 0xFFFF) == 1">
       
         <block>
           // Init AP Transfer Mode, Transaction Counter, and Lane Mask (Normal Transfer Mode, Include all Byte Lanes)
           // Additionally clear STICKYORUN, STICKYCMP, and STICKYERR bits by writing '1'
-          WriteDP(DP_CTRL_STAT, 0x50000F32);
+          WriteDP(DP_CTRL_STAT, 0x50000F00 | JTAG_DP_STICKY_BITS_CLR);
         </block>
         
       </control>
       
-      <!-- SWD Specific Part of sequence -->
+      <!-- SWD specific part -->
       <control if="(__protocol &amp; 0xFFFF) == 2">
       
         <block>
@@ -504,7 +535,7 @@ Connect to the target debug port and power it up.
           WriteDP(DP_CTRL_STAT, 0x50000F00);
           
           // Clear WDATAERR, STICKYORUN, STICKYCMP, and STICKYERR bits of CTRL/STAT Register by write to ABORT register
-          WriteDP(SW_DP_ABORT, 0x0000001E);
+          WriteDP(SW_DP_ABORT, SWD_DP_STICKY_BITS_CLR);
         </block>
 
       </control>

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -25,7 +25,7 @@
   Package file name convention <vendor>.<name>.<version>.pack
   SchemaVersion=1.7.39
 
-  29. Aug 2024: v1.7.39
+  30. Aug 2024: v1.7.39
    - modified default 'DebugPortStart' debug sequence to clear DP sticky error bits (specification docs only)
   13. May 2024: v1.7.37
    - added Nationstech vendor

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -18,14 +18,14 @@
   limitations under the License.
 
 
-  $Date:        28. Aug 2024
+  $Date:        29. Aug 2024
   $Revision:    1.7.39
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
   SchemaVersion=1.7.39
 
-  28. Aug 2024: v1.7.39
+  29. Aug 2024: v1.7.39
    - modified default 'DebugPortStart' debug sequence to clear DP sticky error bits (specification docs only)
   13. May 2024: v1.7.37
    - added Nationstech vendor

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -18,7 +18,7 @@
   limitations under the License.
 
 
-  $Date:        29. Aug 2024
+  $Date:        30. Aug 2024
   $Revision:    1.7.39
   $Project: Schema File for Package Description File Format Specification
 

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -233,7 +233,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.38">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.39">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -18,13 +18,15 @@
   limitations under the License.
 
 
-  $Date:        13. May 2024
-  $Revision:    1.7.37
+  $Date:        28. Aug 2024
+  $Revision:    1.7.39
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
-  SchemaVersion=1.7.37
+  SchemaVersion=1.7.39
 
+  28. Aug 2024: v1.7.39
+   - modified default 'DebugPortStart' debug sequence to clear DP sticky error bits (specification docs only)
   13. May 2024: v1.7.37
    - added Nationstech vendor
    - added NSING vendor
@@ -231,7 +233,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.37">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.38">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">


### PR DESCRIPTION
This PR addresses #324 and provides a proposal for how to update the default `DebugPortStart` debug sequence to check and clear a DP's sticky error bits before starting the DP power-up sequence.

The changed sequence was tested with Keil MDK uVision and Arm Debugger, and with patched variants of real-world DFP PDSC files. Previously failing combinations work now. Previously working combinations didn't show regressions.

This PR updates both the docs revision history and the `Pack.xsd` revision history. Though I am not entirely sure if the latter was really necessary because this effectively is a docs-only change. Note the version gap from a previous docs-only change.