### PR TITLE
Update GitHub Actions runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   docs:
     name: Build main documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install packages

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -25,12 +25,12 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -y graphviz plantuml libclang1-9 libclang-cpp1-9
-      - name: Install doxygen 1.9.2
+          sudo apt-get install --no-install-recommends -y graphviz plantuml
+      - name: Install doxygen 1.9.6
         run: |
-          wget -O doxygen.tgz https://sourceforge.net/projects/doxygen/files/rel-1.9.2/doxygen-1.9.2.linux.bin.tar.gz/download
+          wget -O doxygen.tgz https://sourceforge.net/projects/doxygen/files/rel-1.9.6/doxygen-1.9.6.linux.bin.tar.gz/download
           sudo tar -C /opt -xf doxygen.tgz
-          sudo ln -s /opt/doxygen-1.9.2/bin/doxygen /usr/local/bin/
+          sudo ln -s /opt/doxygen-1.9.6/bin/doxygen /usr/local/bin/
           which doxygen
           doxygen --version
       - name: Install linkchecker

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   pack:
     name: Validate pack schema
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -57,7 +57,7 @@ jobs:
 
   index:
     name: Validate index schema
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install packages

--- a/doxygen/gen_doc.sh
+++ b/doxygen/gen_doc.sh
@@ -5,7 +5,7 @@
 #
 # Pre-requisites:
 # - bash shell (for Windows: install git for Windows)
-# - doxygen 1.9.2
+# - doxygen 1.9.6
 
 set -o pipefail
 
@@ -21,8 +21,8 @@ if [[ ! -f "${DOXYGEN}" ]]; then
 else
     version=$("${DOXYGEN}" --version | sed -r -e 's/.*([1-9][0-9]*\.[0-9]+\.[0-9]+).*/\1/')
     echo "DOXYGEN is ${DOXYGEN} at version ${version}"
-    if [[ "${version}" != "1.9.2" ]]; then
-        echo " >> Version is different from 1.9.2 !" >&2
+    if [[ "${version}" != "1.9.6" ]]; then
+        echo " >> Version is different from 1.9.6 !" >&2
     fi
 fi
 


### PR DESCRIPTION
This PR updates the GitHub Actions runner from ubuntu-20.04 to ubuntu-22.04.