### PR TITLE
Add HPROT and SPROT attributes to accessportV1 and accessportV2 element

### DIFF
--- a/doxygen/pack.dxy
+++ b/doxygen/pack.dxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Open-CMSIS-Pack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Version 1.7.47"
+PROJECT_NUMBER         = "Version 1.7.48"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -81,10 +81,16 @@ packs) and provides useful tips when creating a pack.
     <th>Description</th>
   </tr>
   <tr>
+    <td>1.7.48</td>
+    <td>
+      - add 'HPROT' and 'SPROT' attributes to 'accessportV1' and 'accessportV2' element
+    <td>
+  </tr>
+  <tr>
     <td>1.7.47</td>
-	<td>
-	  - removed optional 'Pname' attribute from 'debugvars' element
-	</td>
+    <td>
+      - removed optional 'Pname' attribute from 'debugvars' element
+    </td>
   </tr>
   <tr>
     <td>1.7.46</td>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -3466,6 +3466,22 @@ An <b>accessportV2</b> must be later selected via <b>__apid</b>. It is not possi
     <td>required</td>
   </tr>
   <tr>
+    <td>HPROT</td>
+    <td>
+      Value for HPROT (AHB Protection Control) bits.
+    </td>
+    <td>NonNegativeInteger</td>
+    <td>optional</td>
+  </tr>
+  <tr>
+    <td>SPROT</td>
+    <td>
+      Value for SPROT (Secure Protection Control) bits.
+    </td>
+    <td>NonNegativeInteger</td>
+    <td>optional</td>
+  </tr>
+  <tr>
     <td>parent</td>
     <td>
       Reference to the <b>__apid</b> of the parent access port if the system contains nested APv2 access ports.<br>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -3464,7 +3464,7 @@ An <b>accessportV2</b> must be later selected via <b>__apid</b>. It is not possi
   <tr>
     <td>SPROT</td>
     <td>
-      Value for SPROT (Secure Protection Control) bits.
+      Value for SPROT (Secure Protection Control) bit.
     </td>
     <td>NonNegativeInteger</td>
     <td>optional</td>

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -18,13 +18,15 @@
   limitations under the License.
 
 
-  $Date:        01. Apr 2025
-  $Revision:    1.7.47
+  $Date:        08. Apr 2025
+  $Revision:    1.7.48
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
-  SchemaVersion=1.7.47
+  SchemaVersion=1.7.48
 
+  08. Apr 2025: v1.7.48
+   - add 'HPROT' and 'SPROT' attributes to 'accessportV1' and 'accessportV2' element
   01. Apr 2025: v1.7.47
    - deprecate 'Pname' attribute in 'debug-vars' element type
   31. Mar 2025: v1.7.46
@@ -248,7 +250,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.47">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.48">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -639,6 +639,8 @@
     <xs:attribute name="__apid" type="xs:unsignedInt" use="required" />
     <xs:attribute name="__dp" type="xs:unsignedInt" use="optional" />
     <xs:attribute name="index" type="xs:unsignedInt" use="required" />
+    <xs:attribute name="HPROT" type="xs:unsignedInt" use="optional" />
+    <xs:attribute name="SPROT" type="xs:unsignedInt" use="optional" />
     <xs:anyAttribute processContents="lax" />
   </xs:complexType>
 
@@ -648,6 +650,8 @@
     <xs:attribute name="__dp" type="xs:unsignedInt" use="optional" />
     <xs:attribute name="address" type="NonNegativeInteger" use="required" />
     <xs:attribute name="parent" type="xs:unsignedInt" use="optional" />
+    <xs:attribute name="HPROT" type="xs:unsignedInt" use="optional" />
+    <xs:attribute name="SPROT" type="xs:unsignedInt" use="optional" />
     <xs:anyAttribute processContents="lax" />
   </xs:complexType>
 


### PR DESCRIPTION
Extend AP information with HPROT and SPROT [#2034](https://github.com/Open-CMSIS-Pack/devtools/issues/2034) 