### PR TITLE
Updated ExampleProjectType to allow the "environment" element to have custom children and custom attributes

### DIFF
--- a/doxygen/src/examples_schema.txt
+++ b/doxygen/src/examples_schema.txt
@@ -278,7 +278,18 @@ The environment element describes the name of the environment and the project fi
 <project>
   <environment name="uv" folder="./ARM" load="ARM/Blinky.uvproj"/>
   <environment name="iar" folder="./IAR" load="IAR/Blinky.ewarm" />
-  <environment name="csolution" folder="./CMSIS/ load="CMSIS/Blinky.csolution.yml" />
+  <environment name="csolution" folder="./CMSIS/" load="CMSIS/Blinky.csolution.yml" />
+</project>
+\endcode
+
+\code
+<project>
+  <environment name="STCube" folder="./ST" load="base_example.ioc" custom="test">
+    <!-- **** ST vendor tools specific elements ***** -->
+  </environment>
+  <environment name="csolution" folder="./OpenCMSIS" load="base_example.csolution.yml">
+    <!-- **** vendor tools specific elements ***** -->
+  </environment>
 </project>
 \endcode
 
@@ -322,6 +333,24 @@ The environment element describes the name of the environment and the project fi
 	</td>
     <td>xs:string</td>
     <td>optional</td>
+  </tr>
+  <tr>
+    <td>any</td>
+    <td>Any attribute that is available for the specified development tool.<br>
+    <td>xs:anyAttribute</td>
+    <td>0..*</td>
+  </tr>
+  <tr>
+    <th>Child Elements</th>
+    <th>Description</th>
+    <th>Type</th>
+    <th>Occurrence</th>
+  </tr>
+  <tr>
+    <td>any</td>
+    <td>Any element that is available for the specified development tool.<br>
+    <td>xs:anyAttribute</td>
+    <td>0..*</td>
   </tr>
 </table>
 

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -18,13 +18,15 @@
   limitations under the License.
 
 
-  $Date:        10. Jul 2025
-  $Revision:    1.7.51
+  $Date:        31. Jul 2025
+  $Revision:    1.7.52
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
-  SchemaVersion=1.7.51
+  SchemaVersion=1.7.52
 
+  31. Jul 2025: v1.7.52
+   - updated ExampleProjectType to allow the "environment" element to have custom children and custom attributes 
   10. Jul 2025: v1.7.51
    - added HrdWyr vendor
   24. Jun 2025: v1.7.50
@@ -1590,13 +1592,23 @@
     <xs:sequence>
       <xs:element name="environment" maxOccurs="unbounded">
         <xs:complexType>
+        
+          <!-- allow any child element -->
+          <xs:sequence>
+            <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
+          </xs:sequence>
+
           <xs:attribute name="name"   type="xs:string" use="required" />
           <xs:attribute name="load"   type="xs:string" use="required" />
           <xs:attribute name="folder" type="xs:string" use="optional" />
+
+          <!-- allow any additional attribute -->
+          <xs:anyAttribute></xs:anyAttribute>
+
         </xs:complexType>
       </xs:element>
     </xs:sequence>
-  </xs:complexType>
+  </xs:complexType>  
 
   <xs:complexType name="BoardReferenceType">
     <xs:attribute name="name"     type="xs:string" use="required" /> <!-- refers to Board Description by name   -->

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -18,14 +18,14 @@
   limitations under the License.
 
 
-  $Date:        31. Jul 2025
+  $Date:        11. Aug 2025
   $Revision:    1.7.52
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
   SchemaVersion=1.7.52
 
-  31. Jul 2025: v1.7.52
+  11. Aug 2025: v1.7.52
    - updated ExampleProjectType to allow the "environment" element to have custom children and custom attributes 
   10. Jul 2025: v1.7.51
    - added HrdWyr vendor
@@ -257,7 +257,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.51">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.52">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">


### PR DESCRIPTION
### Related Issue
https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/issues/355

### Schema Change
This pull request contributes a change to an Open-CMSIS-Pack file schema.
Schema changes have a major impact on the tool ecosystem and need to be done carefully.

### Description
Updated ExampleProjectType to allow the "environment" element to have custom children and custom attributes

- Pack.xsd: updated ExampleProjectType to allow the existing "environment" element to have custom children and custom attributes
- examples_schema.txt: updated documentation accordingly (one more example code + updated table)

### Checklist
- [X] Is the schema file changed, properly?
  - [X] Is the schema version incremented according to [Semantic Versioning](https://semver.org/)?
  - [X] Is the schema file header updated, version and date?
  - [X] Is the schema file change history updated?
  - [x] Does the updated schema file pass [XSD meta schema](https://www.w3.org/2012/04/XMLSchema.xsd) check?
- [X] Is the documentation updated, accordingly?
- [x] Are the [automatic checks](https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/tree/main/.github/workflows) updated or enhanced if required?
- [ ] Are enhancements to [PackChk](https://github.com/Open-CMSIS-Pack/devtools/tree/main/tools/packchk) required to proof semantic usage of changed/added features?
  If yes is the reference to the pull request provided in the description above?



