### PR TITLE
Specify that the numbers provided in the feature elements are decimal…

### DIFF
--- a/doxygen/src/boards_schema.txt
+++ b/doxygen/src/boards_schema.txt
@@ -288,7 +288,7 @@ A list of pre-defined features exists.
   </tr>
 </table>
 
-<p>&nbsp;</p>		
+<p>&nbsp;</p>
 
 \anchor BoardFeatureTypeEnum <b>Table: Board Features</b>
 
@@ -297,6 +297,8 @@ The table below lists predefined board features.
 \note
 - The attribute \a name of the element \ref element_board_feature is a descriptive text for a feature. If \a name is omitted, the <b>Default Name</b> (listed below) is used.
 - <b>Do not repeat</b> the \a n or \a m values in the \a name. Display on websites follows the rule to show \a n x \a name.
+- All numbers are a decimal value. Hexadecimal numbers are not supported.
+
 
 |type=|n=|m=|Default Name|Example|Example shown as|
 |-----|--|--|------------|-------|----------------|

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -1549,10 +1549,12 @@ The list of the pre-defined features for Devices (\ref DeviceFeatureTypeEnum "De
 
 \n
 
-\anchor DeviceFeatureTypeEnum <b>Table: Device Feature Types</b> 
+\anchor DeviceFeatureTypeEnum <b>Table: Device Feature Types</b>
 
 The table lists predefined device features (peripherals).
-\note The attribute \a name of the element \ref element_feature is a descriptive text for a feature. If \a name is omitted, then the <b>Default Name</b> is used.
+\note
+- The attribute \a name of the element \ref element_feature is a descriptive text for a feature. If \a name is omitted, then the <b>Default Name</b> is used.
+- All numbers are a decimal value. Hexadecimal numbers are not supported.
 
 type=|n=|m=|Default Name|Example|Example shown as |
 -----|--|--|------------|-------|---------------- |


### PR DESCRIPTION
… only, and not hexadecimal

After email thread with @KeilChris , we (Microchip) had our `feature name=Memory n=` values in hexadecimal, which renders as 0 on the ARM pack site. So just add a note that the numbers are to be decimal only.