### PR TITLE
Fix typos and incorrect attribute names in documentation

### DIFF
--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -1706,7 +1706,7 @@ debug access variables which are evaluated for the function call.
         - size: Size of a single item to get. Must be in the range of 1 - 8.
 
         <b>Return Value:</b><br>
-        Date value of specified size at buffer offset.
+        Data value of specified size at buffer offset.
     </td>
   </tr>
   <tr>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -3319,12 +3319,12 @@ Pairs of <b>__dp</b> and <b>__ap</b> values must not be used to reference an acc
   </debugport>
 
   <!-- ADIv5 DAP -->
-  <accessportV1 __apid="0" _dp="0" index="0"/>
-  <accessportV1 __apid="1" _dp="0" index="1"/>
+  <accessportV1 __apid="0" __dp="0" index="0"/>
+  <accessportV1 __apid="1" __dp="0" index="1"/>
     
   <!-- ADIv6 DAP -->
-  <accessportV2 __apid="2" _dp="1" address="0x00002000"/>
-  <accessportV2 __apid="3" _dp="1" address="0x00004000"/>
+  <accessportV2 __apid="2" __dp="1" address="0x00002000"/>
+  <accessportV2 __apid="3" __dp="1" address="0x00004000"/>
    
   ...
 </family>


### PR DESCRIPTION
Correct return value description typo and replace invalid _dp attributes with __dp in ADIv5 and ADIv6 access port schema examples.