### PR TITLE
Corrected name from 'FlashBufferWrite' to 'FlashWriteBuffer' in debug access function documentation

### DIFF
--- a/doxygen/pack.dxy
+++ b/doxygen/pack.dxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Open-CMSIS-Pack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Version 1.7.56"
+PROJECT_NUMBER         = "Version 1.7.57"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -81,6 +81,12 @@ packs) and provides useful tips when creating a pack.
     <th>Description</th>
   </tr>
   <tr>
+    <td>1.7.57</td>
+    <td>
+      - corrected name from 'FlashBufferWrite' to 'FlashWriteBuffer' in debug access function documentation
+    </td>
+  </tr>
+  <tr>
     <td>1.7.56</td>
     <td>
       - added "Qorvo:189" Dvendor ID

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -1413,7 +1413,7 @@ debug access variables which are evaluated for the function call.
     </td>
   </tr>
   <tr>
-    <td style="white-space: nowrap"><pre>FlashBufferWrite(addr, offs, len, mode)</pre></td>
+    <td style="white-space: nowrap"><pre>FlashWriteBuffer(addr, offs, len, mode)</pre></td>
     <td>
       Write flash buffer contents into target memory.
       A debugger fills the flash buffer before it executes a flash programming sequence.<br>
@@ -1445,6 +1445,9 @@ debug access variables which are evaluated for the function call.
 
       <b>Return Value:</b><br>
       Always returns \token{0}.
+
+      \note Previous versions of the specification falsely named this function \token{FlashBufferWrite}. All known
+            implementations of this specification correctly use \token{FlashWriteBuffer} already.
     </td>
   </tr>
   <tr>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -902,7 +902,7 @@ identical, the one on the lower level takes precedence. Overlap of Flash informa
   <tr>
     <td>filler</td>
     <td>Value that a debugger uses to fill the remainder of a programming page (64-bit value).
-    The access size used in \ref DebugFunctions "FlashBufferWrite" defines the number of least significant bytes of this value to write.
+    The access size used in \ref DebugFunctions "FlashWriteBuffer" defines the number of least significant bytes of this value to write.
     Defaults to \token{0xFFFFFFFFFFFFFFFF} if not specified.</td>
     <td>NonNegativeInteger</td>
     <td>optional</td>

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -269,7 +269,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.56">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.57">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-  Copyright (c) 2013-2025 ARM Limited, 2025 Arm China. All rights reserved.
+  Copyright (c) 2013-2026 ARM Limited, 2025 Arm China. All rights reserved.
 
   SPDX-License-Identifier: Apache-2.0
 
@@ -18,13 +18,15 @@
   limitations under the License.
 
 
-  $Date:        05. Dec 2025
-  $Revision:    1.7.56
+  $Date:        04. Mar 2026
+  $Revision:    1.7.57
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
-  SchemaVersion=1.7.56
+  SchemaVersion=1.7.57
 
+  04. Mar 2026: v1.7.57
+   - corrected name from 'FlashBufferWrite' to 'FlashWriteBuffer' in debug access function documentation
   05. Dec 2025: v1.7.56
    - added "Qorvo:189" Dvendor ID
   04. Dec 2025: v1.7.55


### PR DESCRIPTION
Address #385 