### PR TITLE
Revert "Extend processor element with NPU attributes"

### DIFF
--- a/doxygen/pack.dxy
+++ b/doxygen/pack.dxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Open-CMSIS-Pack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Version 1.7.58"
+PROJECT_NUMBER         = "Version 1.7.57"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -81,12 +81,6 @@ packs) and provides useful tips when creating a pack.
     <th>Description</th>
   </tr>
   <tr>
-    <td>1.7.58</td>
-    <td>
-      - added processor feature attributes for NPU: 'Dnpu' and 'Dnpu_num_macs'
-    </td>
-  </tr>
-  <tr>
     <td>1.7.57</td>
     <td>
       - corrected name from 'FlashBufferWrite' to 'FlashWriteBuffer' in debug access function documentation

--- a/doxygen/src/conditions_schema.txt
+++ b/doxygen/src/conditions_schema.txt
@@ -271,18 +271,6 @@ A \ref element_condition "condition" becomes \token{true} when:
     <td>required for ARMv8.1-M based devices with PAC/BTI support</td>
   </tr>
   <tr>
-    <td>Dnpu</td>
-    <td>Specifies a neural processing unit (NPU).  Some predefined tokens are listed in the table \ref DnpuEnum "Device NPUs", but any other tokens are allowed, too.</td>
-    <td>\ref DnpuEnum</td>
-    <td>optional</td>
-  </tr>
-  <tr>
-    <td>DnpuMacs</td>
-    <td>Specifies the available MAC units of the selected neural processing unit (NPU). Specified in multiples of 2 and returns true for exact match with the processor attribute specified.</td>
-    <td>\ref DnpuEnum</td>
-    <td>optional</td>
-  </tr>
-  <tr>
     <td>Dendian</td>
     <td>Specifies the endianess of a device. Use predefined values as listed in the table \ref DendianEnum "Endianess".</td>
     <td>\ref DendianEnum</td>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -1997,19 +1997,6 @@ the attribute \elem{Pname}. If the information is relevant to all processors, no
     <td>xs:string</td>
     <td>required</td>
   </tr>
-  <tr>
-    <td>Dnpu</td>
-    <td>Specifies the NPU type implemented if it exists. Some predefined tokens are listed in the table \ref DnpuEnum "Device NPUs", but any other tokens are allowed, too.</td>
-    <td>\ref DnpuEnum</td>
-    <td>optional</td>
-  </tr>
-  <tr>
-    <td>DnpuMacs</td>
-    <td>If an NPU is present, this attribute specifies the number of available MACs.</td>
-    <td>xs:unsignedInt</td>
-    <td>optional</td>
-  </tr>
-
 </table>
 
 \note While the different attributes can be spreaded over the family levels, they add-up and at the leaf (device level), a
@@ -2687,35 +2674,6 @@ These values can be used in the elements:
 
 <p>&nbsp;</p>
 
-\anchor DnpuEnum <b>Table: Device NPU</b>
-
-The table lists a set of defined Neural Processing Units (NPU), but any other token is supported, too. The list is extended with other NPUs upon request.
-These values can be used in the elements:
-- \ref element_accept
-- \ref element_require
-- \ref element_deny
-- \ref element_processor
-	
-<table class="cmtable" summary="Enumeration: Dnpu">
-  <tr>
-    <th>Dnpu=</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td class="XML-Token">Ethos-U55</td>
-    <td>Device featuring an <a href="https://www.arm.com/products/silicon-ip-cpu/ethos/ethos-u55" target="_blank">Arm Ethos-U55</a> NPU.</td>
-  </tr>
-  <tr>
-    <td class="XML-Token">Ethos-U65</td>
-    <td>Device featuring an <a href="https://www.arm.com/products/silicon-ip-cpu/ethos/ethos-u65" target="_blank">Arm Ethos-U65</a> NPU.</td>
-  </tr>
-  <tr>
-    <td class="XML-Token">Ethos-U85</td>
-    <td><a href="Device featuring an <a href="https://www.arm.com/products/silicon-ip-cpu/ethos/ethos-u85" target="_blank">Arm Ethos-U85</a> NPU.</td>
-  </tr>
-</table>
-
-<p>&nbsp;</p>
 
 \anchor DfpuEnum <b>Table: Device FPU</b>
 

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -18,15 +18,13 @@
   limitations under the License.
 
 
-  $Date:        07. April 2026
-  $Revision:    1.7.58
+  $Date:        04. Mar 2026
+  $Revision:    1.7.57
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
-  SchemaVersion=1.7.58
+  SchemaVersion=1.7.57
 
-  07. April 2026: v1.7.58
-   - add processor feature attributes for NPU: 'Dnpu' and 'Dnpu_num_macs'
   04. Mar 2026: v1.7.57
    - corrected name from 'FlashBufferWrite' to 'FlashWriteBuffer' in debug access function documentation
   05. Dec 2025: v1.7.56
@@ -271,7 +269,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.58">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.57">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">
@@ -569,10 +567,6 @@
     <xs:attribute name="Punits" type="InstancesType" />
     <!-- Dcore specifies the processor from a list of supported processors -->
     <xs:attribute name="Dcore" type="DcoreType" />
-    <!-- Dnpu specifies the NPU from a list of supported Arm NPUs -->
-    <xs:attribute name="Dnpu" type="DnpuType" />
-    <!-- DnpuMacs specifies the number of implemented MAC units -->
-    <xs:attribute name="DnpuMacs" type="xs:unsignedInt" />
     <!-- Dfpu specifies the hardware floating point unit -->
     <xs:attribute name="Dfpu" type="DfpuEnum" />
     <!-- Dmpu specifies the memory protection unit -->
@@ -1079,18 +1073,6 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <xs:simpleType name="DnpuType">
-    <xs:union memberTypes="DnpuEnum xs:token"/>
-  </xs:simpleType>
-
-  <xs:simpleType name="DnpuEnum">
-    <xs:restriction base="xs:token">
-	  <xs:enumeration value="Ethos-U55" />
-	  <xs:enumeration value="Ethos-U65" />
-	  <xs:enumeration value="Ethos-U85" />
-	</xs:restriction>
-  </xs:simpleType>
-
   <!-- DeviceFeatureTypeEnum -->
   <xs:simpleType name="DeviceFeatureTypeEnum">
     <xs:restriction base="xs:token">
@@ -1481,7 +1463,6 @@
     <xs:attribute name="Dvendor" type="DeviceVendorEnum" />
     <xs:attribute name="Dname" type="xs:string" /> <!-- can contain wildcards ?* in condition -->
     <xs:attribute name="Dcore" type="DcoreType" />
-	<xs:attribute name="Dnpu"  type="DnpuType" />
     <xs:attribute name="Dfpu" type="DfpuEnum" />
     <xs:attribute name="Dmpu" type="DmpuEnum" />
     <xs:attribute name="Dtz" type="DtzEnum" />


### PR DESCRIPTION
Reverts Open-CMSIS-Pack/Open-CMSIS-Pack-Spec#390
The proposed extension of the `<processor>` element has the limitation that only one NPU can be specified.

Note:
Using the NPU feature including the reference to a `<processor>` via `Pname` allows to specify multiple NPUs for a processor.
If no `Pname` is specified for an NPU feature entry, then it can be used with all available processors.
https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/pdsc_family_pg.html#element_feature
