### PR TITLE
Debug Description: Clarifications and corrections around Flash Debug Sequences

### DIFF
--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -86,6 +86,8 @@ packs) and provides useful tips when creating a pack.
       - adds rules to reserve `__` prefix for debug access variable names provided by spec
       - added '__' prefix to variable names in default debug sequence implementations
       - corrected '__FlashOp' value mapping in debug access variables documentation
+      - clarified usage of 'timeout' in 'BufferStreamIn', 'BufferStreamOut', and 'FilePathExists' debug access functions
+      - changed return values of 'BufferWrite' and 'FlashBufferWrite' from always '0' to number of actually written bytes
     </td>
   </tr>
   <tr>

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -85,6 +85,7 @@ packs) and provides useful tips when creating a pack.
     <td>
       - adds rules to reserve `__` prefix for debug access variable names provided by spec
       - added '__' prefix to variable names in default debug sequence implementations
+      - corrected '__FlashOp' value mapping in debug access variables documentation
     </td>
   </tr>
   <tr>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -1444,10 +1444,15 @@ debug access variables which are evaluated for the function call.
       - __apid: The ID of the access port element to use for this memory access.
 
       <b>Return Value:</b><br>
-      Always returns \token{0}.
+      Number of bytes written from flash buffer to target.
 
       \note Previous versions of the specification falsely named this function \token{FlashBufferWrite}. All known
             implementations of this specification correctly use \token{FlashWriteBuffer} already.
+
+      \note
+      Previous versions specified to always return \token{0} in case of success. This
+      was changed for consistency with other debug access functions handling buffers.
+
     </td>
   </tr>
   <tr>
@@ -1792,7 +1797,11 @@ debug access variables which are evaluated for the function call.
         - __apid: The ID of the access port element to use for this memory access.
 
         <b>Return Value:</b><br>
-        Always \token{0}. Function causes fatal error if not successful.
+        Number of bytes written from buffer to target. Function causes fatal error if not successful.
+
+        \note
+        Previous versions specified to always return \token{0} in case of success. This
+        was changed for consistency with other debug access functions handling buffers.
 
         <b>Code Example:</b><br>
         Refer to \ref exttoolexample "Calculating a hash sum"

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -2083,9 +2083,9 @@ A debugger needs to support a set of pre-defined debug access variables. These a
     <td>
       The following values apply:<br>
       - 0: No flash operation
-      - 1: Erase full chip
-      - 2: Erase flash sector
-      - 3: Program flash
+      - 1: Erase
+      - 2: Program
+      - 3: Verify
       - Other - reserved.
     </td>
   </tr>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -1897,9 +1897,9 @@ debug access variables which are evaluated for the function call.
         - path: Constant string with the path to check. Refer to \ref charactersequence "character sequences" for path/file
 		  name place holders.
         - timeout: Timeout in microseconds:<br>
-          If \token{0}, then the path is checked and the function immediately returns.<br>
-		  If other than \token{0}, check the path until it is valid or until the function times out. If \b timeout is hit
-		  while executing a check and that check ends successfully, then the function returns success.<br>
+          If \token{0}, then the path is checked once before the function returns.<br>
+		  If other than \token{0}, the function checks the path until it is valid or until the function times out. If \b timeout is hit
+		  while executing a check, then the function completes the check and returns its result.<br>
         
         <b>Return Value:</b><br>
         \token{0} - Path exists<br>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -1817,7 +1817,7 @@ debug access variables which are evaluated for the function call.
 			Others - Reserved<br>
           - Bit 4..7: Communication options for data source:<br>
 		    Reserved
-        - timeout: Timeout in microseconds. If \token{0}, then synchronously wait for the operation to finish.
+        - timeout: Timeout of file operation in microseconds. If \token{0}, then synchronously wait for the operation to finish.
         
         <b>Return Value:</b><br>
         Number of bytes streamed into buffer. Can be less than \b length if the data source signals its end.
@@ -1845,7 +1845,9 @@ debug access variables which are evaluated for the function call.
 		    \token{0} - Overwrite<br>
 			\token{1} - Append<br>
 			Others - Reserved<br>
-        - timeout: Timeout in microseconds. If \token{0}, then synchronously wait for the operation to finish.
+        - timeout: Timeout in microseconds. If \token{0}, then synchronously wait for the operation to finish.<br>
+          - This does not include file-system delays, e.g. between creation and visibility in a file browser. Use \b FilePathExists
+            debug access function to wait for a new file to become accessible.
         
         <b>Return Value:</b><br>
         Number of bytes streamed to data sink.


### PR DESCRIPTION
Addresses #389 

Changes:
- Corrected '__FlashOp' value mapping in debug access variables documentation
- Clarified usage of 'timeout' in 'BufferStreamIn', 'BufferStreamOut', and 'FilePathExists' debug access functions
- Changed return values of 'BufferWrite' and 'FlashWriteBuffer' from always '0' to number of actually written bytes. *Breaking change*, but expected to be low impact to existing sequence implementations because the previous value "always 0" was useless to be checked. Kept note about previous behavior, it may take a while until old implementations catch up with this change.

Not addressed:
- Further alignment of timeout behavior of 'BufferStreamIn', 'BufferStreamOut', and 'FilePathExists': Behavior of the first two is identical already (wait synchronously), and behavior of 'FilePathExists' (test once) is not directly comparable. Hence, IMO no need to change.