### PR TITLE
Debug Description: Introduce `__` prefix as reserved for variable names provided by spec

### DIFF
--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -81,6 +81,12 @@ packs) and provides useful tips when creating a pack.
     <th>Description</th>
   </tr>
   <tr>
+    <td>next</td>
+    <td>
+      - added '__' prefix to variable names in default debug sequence implementations
+    </td>
+  </tr>
+  <tr>
     <td>1.7.57</td>
     <td>
       - corrected name from 'FlashBufferWrite' to 'FlashWriteBuffer' in debug access function documentation

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -83,6 +83,7 @@ packs) and provides useful tips when creating a pack.
   <tr>
     <td>next</td>
     <td>
+      - adds rules to reserve `__` prefix for debug access variable names provided by spec
       - added '__' prefix to variable names in default debug sequence implementations
     </td>
   </tr>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -45,8 +45,8 @@ A complete debug description for a device consists of the following elements:
  - \refelem{debug} with the child element \refelem{dbg_datapatch} contains settings for the debug connection and for
    fixing silicon issues in software.
  - \refelem{debugconfig} provides the default debugger configuration for a target connection.
- - \refelem{debugvars} specifies global debug access variables. They can be used in addition to predefined variables in
-   order to query settings from a debug access sequences.
+ - \refelem{debugvars} specifies global debug access variables. They can be used in addition to predefined variables to pass
+ user settings to debug access sequences.
  - \refelem{debugport} with the child elements \refelem{dp_jtag}, \refelem{dp_swd}, and \refelem{dp_cjtag} describes the
    debug port in detail.
  - \refelem{accessportV1} describes an access port (APv1) in detail.
@@ -1920,6 +1920,10 @@ and states. They are <b>read-only</b> within a sequence except from a limited se
 \ref PredefinedDebugVars "pre-defined debug access variables". Use the <b>debugvars</b> element to specify additional
 user-defined debug access variables.
 
+User-defined debug access variable names must not be reused for local sequence variables, including those in default
+sequence implementations. To avoid name clashes, the \token{__} prefix is reserved for variables provided by the
+specification (for example, in default sequence implementations). User-defined debug access variables should avoid
+using the \token{__} prefix.
 
 \anchor PredefinedDebugVars <b>Table: Pre-defined Debug Access Variables</b><br>
 A debugger needs to support a set of pre-defined debug access variables. These are described in the following table.

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -290,17 +290,17 @@ Prepare the target debug port for connection.
 \code  
   <sequence name="DebugPortSetup">
     <block>
-      __var isSWJ      = ((__protocol &amp; 0x00010000) != 0);
-      __var hasDormant = __protocol &amp; 0x00020000;
-      __var protType   = __protocol &amp; 0x0000FFFF;
+      __var __isSWJ      = ((__protocol &amp; 0x00010000) != 0);
+      __var __hasDormant = __protocol &amp; 0x00020000;
+      __var __protType   = __protocol &amp; 0x0000FFFF;
     </block>
     
     <!-- JTAG Protocol -->
-    <control if="protType == 1">
+    <control if="__protType == 1">
     
-      <control if="isSWJ">
+      <control if="__isSWJ">
     
-        <control if="hasDormant">
+        <control if="__hasDormant">
     
           <block atomic="1">
             // Ensure current debug interface is in reset state
@@ -327,7 +327,7 @@ Prepare the target debug port for connection.
     
         </control>
     
-        <control if="!hasDormant">
+        <control if="!__hasDormant">
     
           <block atomic="1">
             // Ensure current debug interface is in reset state
@@ -354,11 +354,11 @@ Prepare the target debug port for connection.
     </control>
     
     <!-- SWD Protocol -->
-    <control if="protType == 2">
+    <control if="__protType == 2">
     
-      <control if="isSWJ">
+      <control if="__isSWJ">
         
-        <control if="hasDormant">
+        <control if="__hasDormant">
     
           <block atomic="1">
             // Ensure current debug interface is in reset state
@@ -386,7 +386,7 @@ Prepare the target debug port for connection.
     
         </control>
     
-        <control if="!hasDormant">
+        <control if="!__hasDormant">
     
           <block atomic="1">
             // Ensure current debug interface is in reset state
@@ -405,9 +405,9 @@ Prepare the target debug port for connection.
     
       </control>
     
-      <control if="!isSWJ">
+      <control if="!__isSWJ">
       
-        <control if="hasDormant">
+        <control if="__hasDormant">
     
           <block atomic="1">
             // Ensure current debug interface is in reset state
@@ -432,7 +432,7 @@ Prepare the target debug port for connection.
     
         </control>
     
-        <control if="!hasDormant">
+        <control if="!__hasDormant">
     
           <block atomic="1">
             // Enter SWD Line Reset State
@@ -463,32 +463,32 @@ Connect to the target debug port and power it up.
   <sequence name="DebugPortStart">
     
     <block>
-      __var SW_DP_ABORT    = 0x0;
-      __var DP_CTRL_STAT   = 0x4;
-      __var DP_SELECT      = 0x8;
-      __var DP_STICKY_BITS = 0x000000B2;          // DP CTRL/STAT: STICKYORUN | STICKYCMP | STICKYERR | WDATAERR
-      __var JTAG_DP_STICKY_BITS_CLR = 0x00000032; // DP CTRL/STAT: STICKYORUN | STICKYCMP | STICKYERR
-      __var SWD_DP_STICKY_BITS_CLR  = 0x0000001E; // DP ABORT: ORUNERRCLR | WDERRCLR | STKERRCLR | STKCMPCLR
-      __var powered_down   = 0;
-      __var ctrl_stat_val  = 0;
+      __var __SW_DP_ABORT    = 0x0;
+      __var __DP_CTRL_STAT   = 0x4;
+      __var __DP_SELECT      = 0x8;
+      __var __DP_STICKY_BITS = 0x000000B2;          // DP CTRL/STAT: STICKYORUN | STICKYCMP | STICKYERR | WDATAERR
+      __var __JTAG_DP_STICKY_BITS_CLR = 0x00000032; // DP CTRL/STAT: STICKYORUN | STICKYCMP | STICKYERR
+      __var __SWD_DP_STICKY_BITS_CLR  = 0x0000001E; // DP ABORT: ORUNERRCLR | WDERRCLR | STKERRCLR | STKCMPCLR
+      __var __powered_down   = 0;
+      __var __ctrl_stat_val  = 0;
 
       // Switch to DP Register Bank 0
-      WriteDP(DP_SELECT, 0x00000000);
+      WriteDP(__DP_SELECT, 0x00000000);
     
       // Read DP CTRL/STAT Register and check if CSYSPWRUPACK and CDBGPWRUPACK bits are set
-      ctrl_stat_val = ReadDP(DP_CTRL_STAT);
-      powered_down = ((ctrl_stat_val &amp; 0xA0000000) != 0xA0000000);
+      __ctrl_stat_val = ReadDP(__DP_CTRL_STAT);
+      __powered_down = ((__ctrl_stat_val &amp; 0xA0000000) != 0xA0000000);
     </block>
     
     <!-- Check and clear sticky error bits -->
-    <control if="ctrl_stat_val &amp; DP_STICKY_BITS">
+    <control if="__ctrl_stat_val &amp; __DP_STICKY_BITS">
 
       <!-- JTAG specific part -->
       <control if="(__protocol &amp; 0xFFFF) == 1">
 
         <block>
           // Clear JTAG-DP sticky error bits by writing '1', preserve other values
-          WriteDP(DP_CTRL_STAT, ctrl_stat_val | JTAG_DP_STICKY_BITS_CLR);
+          WriteDP(__DP_CTRL_STAT, __ctrl_stat_val | __JTAG_DP_STICKY_BITS_CLR);
         </block>
 
       </control>
@@ -498,7 +498,7 @@ Connect to the target debug port and power it up.
 
         <block>
           // Clear SWD-DP sticky error bits by writing to DP ABORT
-          WriteDP(SW_DP_ABORT, SWD_DP_STICKY_BITS_CLR);
+          WriteDP(__SW_DP_ABORT, __SWD_DP_STICKY_BITS_CLR);
         </block>
 
       </control>
@@ -506,15 +506,15 @@ Connect to the target debug port and power it up.
     </control>
 
     <!-- Check if DP is powered down and power it up if so -->
-    <control if="powered_down">
+    <control if="__powered_down">
     
       <block>
         // Request Debug/System Power-Up
-        WriteDP(DP_CTRL_STAT, 0x50000000);
+        WriteDP(__DP_CTRL_STAT, 0x50000000);
       </block>
       
       <!-- Wait for Power-Up Request to be acknowledged -->
-      <control while="(ReadDP(DP_CTRL_STAT) &amp; 0xA0000000) != 0xA0000000" timeout="1000000"/>
+      <control while="(ReadDP(__DP_CTRL_STAT) &amp; 0xA0000000) != 0xA0000000" timeout="1000000"/>
       
       <!-- JTAG specific part -->
       <control if="(__protocol &amp; 0xFFFF) == 1">
@@ -522,7 +522,7 @@ Connect to the target debug port and power it up.
         <block>
           // Init AP Transfer Mode, Transaction Counter, and Lane Mask (Normal Transfer Mode, Include all Byte Lanes)
           // Additionally clear STICKYORUN, STICKYCMP, and STICKYERR bits by writing '1'
-          WriteDP(DP_CTRL_STAT, 0x50000F00 | JTAG_DP_STICKY_BITS_CLR);
+          WriteDP(__DP_CTRL_STAT, 0x50000F00 | __JTAG_DP_STICKY_BITS_CLR);
         </block>
         
       </control>
@@ -532,10 +532,10 @@ Connect to the target debug port and power it up.
       
         <block>
           // Init AP Transfer Mode, Transaction Counter, and Lane Mask (Normal Transfer Mode, Include all Byte Lanes)
-          WriteDP(DP_CTRL_STAT, 0x50000F00);
+          WriteDP(__DP_CTRL_STAT, 0x50000F00);
           
           // Clear WDATAERR, STICKYORUN, STICKYCMP, and STICKYERR bits of CTRL/STAT Register by write to ABORT register
-          WriteDP(SW_DP_ABORT, SWD_DP_STICKY_BITS_CLR);
+          WriteDP(__SW_DP_ABORT, __SWD_DP_STICKY_BITS_CLR);
         </block>
 
       </control>
@@ -553,14 +553,14 @@ Power down and disconnect from target debug port.
   <sequence name="DebugPortStop">
   
     <block>
-      __var DP_CTRL_STAT = 0x4;
-      __var DP_SELECT    = 0x8;
+      __var __DP_CTRL_STAT = 0x4;
+      __var __DP_SELECT    = 0x8;
       
       // Switch to DP Register Bank 0
-      WriteDP(DP_SELECT, 0x00000000);
+      WriteDP(__DP_SELECT, 0x00000000);
       
       // Power Down Debug port
-      WriteDP(DP_CTRL_STAT, 0x00000000);
+      WriteDP(__DP_CTRL_STAT, 0x00000000);
     </block>
   
   </sequence>
@@ -577,11 +577,11 @@ Initialize core debug system.
     <block>
       // System Control Space (SCS) offset as defined in Armv6-M/Armv7-M.
     
-      __var SCS_Addr   = 0xE000E000;
-      __var DHCSR_Addr = SCS_Addr + 0xDF0;
+      __var __SCS_Addr   = 0xE000E000;
+      __var __DHCSR_Addr = __SCS_Addr + 0xDF0;
 
       // Enable Core Debug via DHCSR
-      Write32(DHCSR_Addr, 0xA05F0001);
+      Write32(__DHCSR_Addr, 0xA05F0001);
     </block>
     
   </sequence>
@@ -598,16 +598,16 @@ Un-initialize core debug system.
     <block>
       // System Control Space (SCS) offset as defined in Armv6-M/Armv7-M.
       
-      __var SCS_Addr   = 0xE000E000;
-      __var DHCSR_Addr = SCS_Addr + 0xDF0;
-      __var DEMCR_Addr = SCS_Addr + 0xDFC;
+      __var __SCS_Addr   = 0xE000E000;
+      __var __DHCSR_Addr = __SCS_Addr + 0xDF0;
+      __var __DEMCR_Addr = __SCS_Addr + 0xDFC;
       
       // Disable Core Debug via DHCSR
-      Write32(DHCSR_Addr, 0xA05F0000);
+      Write32(__DHCSR_Addr, 0xA05F0000);
       
       // Disable DWT and ITM blocks, DebugMonitor handler,
       // halting debug traps, and Reset Vector Catch.
-      Write32(DEMCR_Addr, 0x00000000);
+      Write32(__DEMCR_Addr, 0x00000000);
     </block>
     
   </sequence>
@@ -624,16 +624,16 @@ Default implementation for \b ResetSystem debug access sequence that executes a 
     <block>
       // System Control Space (SCS) offset as defined in Armv6-M/Armv7-M.
 
-      __var SCS_Addr   = 0xE000E000;
-      __var AIRCR_Addr = SCS_Addr + 0xD0C;
-      __var DHCSR_Addr = SCS_Addr + 0xDF0;
+      __var __SCS_Addr   = 0xE000E000;
+      __var __AIRCR_Addr = __SCS_Addr + 0xD0C;
+      __var __DHCSR_Addr = __SCS_Addr + 0xDF0;
     
       // Execute SYSRESETREQ via AIRCR
-      Write32(AIRCR_Addr, 0x05FA0004);
+      Write32(__AIRCR_Addr, 0x05FA0004);
     </block>
 
     <!-- Reset Recovery: Wait for DHCSR.S_RESET_ST bit to clear on read -->
-    <control while="(Read32(DHCSR_Addr) &amp; 0x02000000)" timeout="500000"/>
+    <control while="(Read32(__DHCSR_Addr) &amp; 0x02000000)" timeout="500000"/>
     
   </sequence>
 \endcode
@@ -651,16 +651,16 @@ Default implementation for \b ResetProcessor debug access sequence that executes
     <block>
       // System Control Space (SCS) offset as defined in Armv7-M.
 
-      __var SCS_Addr   = 0xE000E000;
-      __var AIRCR_Addr = SCS_Addr + 0xD0C;
-      __var DHCSR_Addr = SCS_Addr + 0xDF0;
+      __var __SCS_Addr   = 0xE000E000;
+      __var __AIRCR_Addr = __SCS_Addr + 0xD0C;
+      __var __DHCSR_Addr = __SCS_Addr + 0xDF0;
     
       // Execute VECTRESET via AIRCR
-      Write32(AIRCR_Addr, 0x05FA0001);
+      Write32(__AIRCR_Addr, 0x05FA0001);
     </block>
     
     <!-- Reset Recovery: Wait for DHCSR.S_RESET_ST bit to clear on read -->
-    <control while="(Read32(DHCSR_Addr) &amp; 0x02000000)" timeout="500000"/>
+    <control while="(Read32(__DHCSR_Addr) &amp; 0x02000000)" timeout="500000"/>
 
   </sequence>
 \endcode
@@ -675,28 +675,28 @@ Default implementation for \b ResetHardware debug access sequence that executes 
   <sequence name="ResetHardware">
     
     <block>
-      __var nReset      = 0x80;
-      __var canReadPins = 0;
+      __var __nReset      = 0x80;
+      __var __canReadPins = 0;
     
       // De-assert nRESET line
-      canReadPins = (DAP_SWJ_Pins(0x00, nReset, 0) != 0xFFFFFFFF);
+      __canReadPins = (DAP_SWJ_Pins(0x00, __nReset, 0) != 0xFFFFFFFF);
     </block>
     
     <!-- Keep reset active for 50 ms -->
     <control while="1" timeout="50000"/>
 
-    <control if="canReadPins">
+    <control if="__canReadPins">
     
       <!-- Assert nRESET line and wait max. 1s for recovery -->
-      <control while="(DAP_SWJ_Pins(nReset, nReset, 0) &amp; nReset) == 0" timeout="1000000"/>
+      <control while="(DAP_SWJ_Pins(__nReset, __nReset, 0) &amp; __nReset) == 0" timeout="1000000"/>
       
     </control>
     
-    <control if="!canReadPins">
+    <control if="!__canReadPins">
     
       <block>
         // Assert nRESET line
-        DAP_SWJ_Pins(nReset, nReset, 0);
+        DAP_SWJ_Pins(__nReset, __nReset, 0);
       </block>
       
       <!-- Wait 100ms for recovery if nRESET not readable -->
@@ -716,10 +716,10 @@ Assert a system-wide reset line nRST.
   <sequence name="ResetHardwareAssert">
 
     <block>
-        __var nReset = 0x80;
+      __var __nReset = 0x80;
       
-        // De-assert nRESET line to activate the hardware reset
-        DAP_SWJ_Pins(0, nReset, 0);
+      // De-assert nRESET line to activate the hardware reset
+      DAP_SWJ_Pins(0, __nReset, 0);
     </block>
     
   </sequence>
@@ -734,18 +734,18 @@ De-Assert a system-wide reset line nRST.
   <sequence name="ResetHardwareDeassert">
 
     <block>
-      __var nReset      = 0x80;
-      __var canReadPins = 0;
+      __var __nReset      = 0x80;
+      __var __canReadPins = 0;
       
       // Assert nRESET line and check if nRESET is readable
-      canReadPins = (DAP_SWJ_Pins(nReset, nReset, 0) != 0xFFFFFFFF);
+      __canReadPins = (DAP_SWJ_Pins(__nReset, __nReset, 0) != 0xFFFFFFFF);
     </block>
 
     <!-- Wait max. 1s for nRESET to recover from reset if readable-->
-    <control if="canReadPins" while="(DAP_SWJ_Pins(nReset, nReset, 0) &amp; nReset) == 0" timeout="1000000"/>
+    <control if="__canReadPins" while="(DAP_SWJ_Pins(__nReset, __nReset, 0) &amp; __nReset) == 0" timeout="1000000"/>
     
     <!-- Wait 100ms for recovery if nRESET not readable -->
-    <control if="!canReadPins" while="1" timeout="100000"/>
+    <control if="!__canReadPins" while="1" timeout="100000"/>
   
   </sequence>
         
@@ -764,17 +764,17 @@ Configure the target to stop code execution after a reset.
       // in Armv6-M/Armv7-M. Reimplement this sequence
       // if the SCS is located at a different offset.
 
-      __var SCS_Addr   = 0xE000E000;
-      __var DHCSR_Addr = SCS_Addr + 0xDF0;
-      __var DEMCR_Addr = SCS_Addr + 0xDFC;
-      __var value      = 0;
+      __var __SCS_Addr   = 0xE000E000;
+      __var __DHCSR_Addr = __SCS_Addr + 0xDF0;
+      __var __DEMCR_Addr = __SCS_Addr + 0xDFC;
+      __var __value      = 0;
     
       // Enable Reset Vector Catch in DEMCR
-      value = Read32(DEMCR_Addr);
-      Write32(DEMCR_Addr, (value | 0x00000001));
+      __value = Read32(__DEMCR_Addr);
+      Write32(__DEMCR_Addr, (__value | 0x00000001));
 
       // Read DHCSR to clear potentially set DHCSR.S_RESET_ST bit
-      Read32(DHCSR_Addr);
+      Read32(__DHCSR_Addr);
     </block>
   
   </sequence>
@@ -793,13 +793,13 @@ Free hardware resources allocated by ResetCatchSet.
       // in Armv6-M/Armv7-M. Reimplement this sequence
       // if the SCS is located at a different offset.
       
-      __var SCS_Addr   = 0xE000E000;
-      __var DEMCR_Addr = SCS_Addr + 0xDFC;
-      __var value      = 0;
+      __var __SCS_Addr   = 0xE000E000;
+      __var __DEMCR_Addr = __SCS_Addr + 0xDFC;
+      __var __value      = 0;
       
       // Disable Reset Vector Catch in DEMCR
-      value = Read32(DEMCR_Addr);
-      Write32(DEMCR_Addr, (value &amp; (~0x00000001)));
+      __value = Read32(__DEMCR_Addr);
+      Write32(__DEMCR_Addr, (__value &amp; (~0x00000001)));
     </block>
     
   </sequence>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -290,17 +290,17 @@ Prepare the target debug port for connection.
 \code  
   <sequence name="DebugPortSetup">
     <block>
-      __var __isSWJ      = ((__protocol &amp; 0x00010000) != 0);
-      __var __hasDormant = __protocol &amp; 0x00020000;
-      __var __protType   = __protocol &amp; 0x0000FFFF;
+      __var isSWJ      = ((__protocol &amp; 0x00010000) != 0);
+      __var hasDormant = __protocol &amp; 0x00020000;
+      __var protType   = __protocol &amp; 0x0000FFFF;
     </block>
     
     <!-- JTAG Protocol -->
-    <control if="__protType == 1">
+    <control if="protType == 1">
     
-      <control if="__isSWJ">
+      <control if="isSWJ">
     
-        <control if="__hasDormant">
+        <control if="hasDormant">
     
           <block atomic="1">
             // Ensure current debug interface is in reset state
@@ -327,7 +327,7 @@ Prepare the target debug port for connection.
     
         </control>
     
-        <control if="!__hasDormant">
+        <control if="!hasDormant">
     
           <block atomic="1">
             // Ensure current debug interface is in reset state
@@ -354,11 +354,11 @@ Prepare the target debug port for connection.
     </control>
     
     <!-- SWD Protocol -->
-    <control if="__protType == 2">
+    <control if="protType == 2">
     
-      <control if="__isSWJ">
+      <control if="isSWJ">
         
-        <control if="__hasDormant">
+        <control if="hasDormant">
     
           <block atomic="1">
             // Ensure current debug interface is in reset state
@@ -386,7 +386,7 @@ Prepare the target debug port for connection.
     
         </control>
     
-        <control if="!__hasDormant">
+        <control if="!hasDormant">
     
           <block atomic="1">
             // Ensure current debug interface is in reset state
@@ -405,9 +405,9 @@ Prepare the target debug port for connection.
     
       </control>
     
-      <control if="!__isSWJ">
+      <control if="!isSWJ">
       
-        <control if="__hasDormant">
+        <control if="hasDormant">
     
           <block atomic="1">
             // Ensure current debug interface is in reset state
@@ -432,7 +432,7 @@ Prepare the target debug port for connection.
     
         </control>
     
-        <control if="!__hasDormant">
+        <control if="!hasDormant">
     
           <block atomic="1">
             // Enter SWD Line Reset State
@@ -463,32 +463,32 @@ Connect to the target debug port and power it up.
   <sequence name="DebugPortStart">
     
     <block>
-      __var __SW_DP_ABORT    = 0x0;
-      __var __DP_CTRL_STAT   = 0x4;
-      __var __DP_SELECT      = 0x8;
-      __var __DP_STICKY_BITS = 0x000000B2;          // DP CTRL/STAT: STICKYORUN | STICKYCMP | STICKYERR | WDATAERR
-      __var __JTAG_DP_STICKY_BITS_CLR = 0x00000032; // DP CTRL/STAT: STICKYORUN | STICKYCMP | STICKYERR
-      __var __SWD_DP_STICKY_BITS_CLR  = 0x0000001E; // DP ABORT: ORUNERRCLR | WDERRCLR | STKERRCLR | STKCMPCLR
-      __var __powered_down   = 0;
-      __var __ctrl_stat_val  = 0;
+      __var SW_DP_ABORT    = 0x0;
+      __var DP_CTRL_STAT   = 0x4;
+      __var DP_SELECT      = 0x8;
+      __var DP_STICKY_BITS = 0x000000B2;          // DP CTRL/STAT: STICKYORUN | STICKYCMP | STICKYERR | WDATAERR
+      __var JTAG_DP_STICKY_BITS_CLR = 0x00000032; // DP CTRL/STAT: STICKYORUN | STICKYCMP | STICKYERR
+      __var SWD_DP_STICKY_BITS_CLR  = 0x0000001E; // DP ABORT: ORUNERRCLR | WDERRCLR | STKERRCLR | STKCMPCLR
+      __var powered_down   = 0;
+      __var ctrl_stat_val  = 0;
 
       // Switch to DP Register Bank 0
-      WriteDP(__DP_SELECT, 0x00000000);
+      WriteDP(DP_SELECT, 0x00000000);
     
       // Read DP CTRL/STAT Register and check if CSYSPWRUPACK and CDBGPWRUPACK bits are set
-      __ctrl_stat_val = ReadDP(__DP_CTRL_STAT);
-      __powered_down = ((__ctrl_stat_val &amp; 0xA0000000) != 0xA0000000);
+      ctrl_stat_val = ReadDP(DP_CTRL_STAT);
+      powered_down = ((ctrl_stat_val &amp; 0xA0000000) != 0xA0000000);
     </block>
     
     <!-- Check and clear sticky error bits -->
-    <control if="__ctrl_stat_val &amp; __DP_STICKY_BITS">
+    <control if="ctrl_stat_val &amp; DP_STICKY_BITS">
 
       <!-- JTAG specific part -->
       <control if="(__protocol &amp; 0xFFFF) == 1">
 
         <block>
           // Clear JTAG-DP sticky error bits by writing '1', preserve other values
-          WriteDP(__DP_CTRL_STAT, __ctrl_stat_val | __JTAG_DP_STICKY_BITS_CLR);
+          WriteDP(DP_CTRL_STAT, ctrl_stat_val | JTAG_DP_STICKY_BITS_CLR);
         </block>
 
       </control>
@@ -498,7 +498,7 @@ Connect to the target debug port and power it up.
 
         <block>
           // Clear SWD-DP sticky error bits by writing to DP ABORT
-          WriteDP(__SW_DP_ABORT, __SWD_DP_STICKY_BITS_CLR);
+          WriteDP(SW_DP_ABORT, SWD_DP_STICKY_BITS_CLR);
         </block>
 
       </control>
@@ -506,15 +506,15 @@ Connect to the target debug port and power it up.
     </control>
 
     <!-- Check if DP is powered down and power it up if so -->
-    <control if="__powered_down">
+    <control if="powered_down">
     
       <block>
         // Request Debug/System Power-Up
-        WriteDP(__DP_CTRL_STAT, 0x50000000);
+        WriteDP(DP_CTRL_STAT, 0x50000000);
       </block>
       
       <!-- Wait for Power-Up Request to be acknowledged -->
-      <control while="(ReadDP(__DP_CTRL_STAT) &amp; 0xA0000000) != 0xA0000000" timeout="1000000"/>
+      <control while="(ReadDP(DP_CTRL_STAT) &amp; 0xA0000000) != 0xA0000000" timeout="1000000"/>
       
       <!-- JTAG specific part -->
       <control if="(__protocol &amp; 0xFFFF) == 1">
@@ -522,7 +522,7 @@ Connect to the target debug port and power it up.
         <block>
           // Init AP Transfer Mode, Transaction Counter, and Lane Mask (Normal Transfer Mode, Include all Byte Lanes)
           // Additionally clear STICKYORUN, STICKYCMP, and STICKYERR bits by writing '1'
-          WriteDP(__DP_CTRL_STAT, 0x50000F00 | __JTAG_DP_STICKY_BITS_CLR);
+          WriteDP(DP_CTRL_STAT, 0x50000F00 | JTAG_DP_STICKY_BITS_CLR);
         </block>
         
       </control>
@@ -532,10 +532,10 @@ Connect to the target debug port and power it up.
       
         <block>
           // Init AP Transfer Mode, Transaction Counter, and Lane Mask (Normal Transfer Mode, Include all Byte Lanes)
-          WriteDP(__DP_CTRL_STAT, 0x50000F00);
+          WriteDP(DP_CTRL_STAT, 0x50000F00);
           
           // Clear WDATAERR, STICKYORUN, STICKYCMP, and STICKYERR bits of CTRL/STAT Register by write to ABORT register
-          WriteDP(__SW_DP_ABORT, __SWD_DP_STICKY_BITS_CLR);
+          WriteDP(SW_DP_ABORT, SWD_DP_STICKY_BITS_CLR);
         </block>
 
       </control>
@@ -553,14 +553,14 @@ Power down and disconnect from target debug port.
   <sequence name="DebugPortStop">
   
     <block>
-      __var __DP_CTRL_STAT = 0x4;
-      __var __DP_SELECT    = 0x8;
+      __var DP_CTRL_STAT = 0x4;
+      __var DP_SELECT    = 0x8;
       
       // Switch to DP Register Bank 0
-      WriteDP(__DP_SELECT, 0x00000000);
+      WriteDP(DP_SELECT, 0x00000000);
       
       // Power Down Debug port
-      WriteDP(__DP_CTRL_STAT, 0x00000000);
+      WriteDP(DP_CTRL_STAT, 0x00000000);
     </block>
   
   </sequence>
@@ -577,11 +577,11 @@ Initialize core debug system.
     <block>
       // System Control Space (SCS) offset as defined in Armv6-M/Armv7-M.
     
-      __var __SCS_Addr   = 0xE000E000;
-      __var __DHCSR_Addr = __SCS_Addr + 0xDF0;
+      __var SCS_Addr   = 0xE000E000;
+      __var DHCSR_Addr = SCS_Addr + 0xDF0;
 
       // Enable Core Debug via DHCSR
-      Write32(__DHCSR_Addr, 0xA05F0001);
+      Write32(DHCSR_Addr, 0xA05F0001);
     </block>
     
   </sequence>
@@ -598,16 +598,16 @@ Un-initialize core debug system.
     <block>
       // System Control Space (SCS) offset as defined in Armv6-M/Armv7-M.
       
-      __var __SCS_Addr   = 0xE000E000;
-      __var __DHCSR_Addr = __SCS_Addr + 0xDF0;
-      __var __DEMCR_Addr = __SCS_Addr + 0xDFC;
+      __var SCS_Addr   = 0xE000E000;
+      __var DHCSR_Addr = SCS_Addr + 0xDF0;
+      __var DEMCR_Addr = SCS_Addr + 0xDFC;
       
       // Disable Core Debug via DHCSR
-      Write32(__DHCSR_Addr, 0xA05F0000);
+      Write32(DHCSR_Addr, 0xA05F0000);
       
       // Disable DWT and ITM blocks, DebugMonitor handler,
       // halting debug traps, and Reset Vector Catch.
-      Write32(__DEMCR_Addr, 0x00000000);
+      Write32(DEMCR_Addr, 0x00000000);
     </block>
     
   </sequence>
@@ -624,16 +624,16 @@ Default implementation for \b ResetSystem debug access sequence that executes a 
     <block>
       // System Control Space (SCS) offset as defined in Armv6-M/Armv7-M.
 
-      __var __SCS_Addr   = 0xE000E000;
-      __var __AIRCR_Addr = __SCS_Addr + 0xD0C;
-      __var __DHCSR_Addr = __SCS_Addr + 0xDF0;
+      __var SCS_Addr   = 0xE000E000;
+      __var AIRCR_Addr = SCS_Addr + 0xD0C;
+      __var DHCSR_Addr = SCS_Addr + 0xDF0;
     
       // Execute SYSRESETREQ via AIRCR
-      Write32(__AIRCR_Addr, 0x05FA0004);
+      Write32(AIRCR_Addr, 0x05FA0004);
     </block>
 
     <!-- Reset Recovery: Wait for DHCSR.S_RESET_ST bit to clear on read -->
-    <control while="(Read32(__DHCSR_Addr) &amp; 0x02000000)" timeout="500000"/>
+    <control while="(Read32(DHCSR_Addr) &amp; 0x02000000)" timeout="500000"/>
     
   </sequence>
 \endcode
@@ -651,16 +651,16 @@ Default implementation for \b ResetProcessor debug access sequence that executes
     <block>
       // System Control Space (SCS) offset as defined in Armv7-M.
 
-      __var __SCS_Addr   = 0xE000E000;
-      __var __AIRCR_Addr = __SCS_Addr + 0xD0C;
-      __var __DHCSR_Addr = __SCS_Addr + 0xDF0;
+      __var SCS_Addr   = 0xE000E000;
+      __var AIRCR_Addr = SCS_Addr + 0xD0C;
+      __var DHCSR_Addr = SCS_Addr + 0xDF0;
     
       // Execute VECTRESET via AIRCR
-      Write32(__AIRCR_Addr, 0x05FA0001);
+      Write32(AIRCR_Addr, 0x05FA0001);
     </block>
     
     <!-- Reset Recovery: Wait for DHCSR.S_RESET_ST bit to clear on read -->
-    <control while="(Read32(__DHCSR_Addr) &amp; 0x02000000)" timeout="500000"/>
+    <control while="(Read32(DHCSR_Addr) &amp; 0x02000000)" timeout="500000"/>
 
   </sequence>
 \endcode
@@ -675,28 +675,28 @@ Default implementation for \b ResetHardware debug access sequence that executes 
   <sequence name="ResetHardware">
     
     <block>
-      __var __nReset      = 0x80;
-      __var __canReadPins = 0;
+      __var nReset      = 0x80;
+      __var canReadPins = 0;
     
       // De-assert nRESET line
-      __canReadPins = (DAP_SWJ_Pins(0x00, __nReset, 0) != 0xFFFFFFFF);
+      canReadPins = (DAP_SWJ_Pins(0x00, nReset, 0) != 0xFFFFFFFF);
     </block>
     
     <!-- Keep reset active for 50 ms -->
     <control while="1" timeout="50000"/>
 
-    <control if="__canReadPins">
+    <control if="canReadPins">
     
       <!-- Assert nRESET line and wait max. 1s for recovery -->
-      <control while="(DAP_SWJ_Pins(__nReset, __nReset, 0) &amp; __nReset) == 0" timeout="1000000"/>
+      <control while="(DAP_SWJ_Pins(nReset, nReset, 0) &amp; nReset) == 0" timeout="1000000"/>
       
     </control>
     
-    <control if="!__canReadPins">
+    <control if="!canReadPins">
     
       <block>
         // Assert nRESET line
-        DAP_SWJ_Pins(__nReset, __nReset, 0);
+        DAP_SWJ_Pins(nReset, nReset, 0);
       </block>
       
       <!-- Wait 100ms for recovery if nRESET not readable -->
@@ -716,10 +716,10 @@ Assert a system-wide reset line nRST.
   <sequence name="ResetHardwareAssert">
 
     <block>
-      __var __nReset = 0x80;
+        __var nReset = 0x80;
       
-      // De-assert nRESET line to activate the hardware reset
-      DAP_SWJ_Pins(0, __nReset, 0);
+        // De-assert nRESET line to activate the hardware reset
+        DAP_SWJ_Pins(0, nReset, 0);
     </block>
     
   </sequence>
@@ -734,18 +734,18 @@ De-Assert a system-wide reset line nRST.
   <sequence name="ResetHardwareDeassert">
 
     <block>
-      __var __nReset      = 0x80;
-      __var __canReadPins = 0;
+      __var nReset      = 0x80;
+      __var canReadPins = 0;
       
       // Assert nRESET line and check if nRESET is readable
-      __canReadPins = (DAP_SWJ_Pins(__nReset, __nReset, 0) != 0xFFFFFFFF);
+      canReadPins = (DAP_SWJ_Pins(nReset, nReset, 0) != 0xFFFFFFFF);
     </block>
 
     <!-- Wait max. 1s for nRESET to recover from reset if readable-->
-    <control if="__canReadPins" while="(DAP_SWJ_Pins(__nReset, __nReset, 0) &amp; __nReset) == 0" timeout="1000000"/>
+    <control if="canReadPins" while="(DAP_SWJ_Pins(nReset, nReset, 0) &amp; nReset) == 0" timeout="1000000"/>
     
     <!-- Wait 100ms for recovery if nRESET not readable -->
-    <control if="!__canReadPins" while="1" timeout="100000"/>
+    <control if="!canReadPins" while="1" timeout="100000"/>
   
   </sequence>
         
@@ -764,17 +764,17 @@ Configure the target to stop code execution after a reset.
       // in Armv6-M/Armv7-M. Reimplement this sequence
       // if the SCS is located at a different offset.
 
-      __var __SCS_Addr   = 0xE000E000;
-      __var __DHCSR_Addr = __SCS_Addr + 0xDF0;
-      __var __DEMCR_Addr = __SCS_Addr + 0xDFC;
-      __var __value      = 0;
+      __var SCS_Addr   = 0xE000E000;
+      __var DHCSR_Addr = SCS_Addr + 0xDF0;
+      __var DEMCR_Addr = SCS_Addr + 0xDFC;
+      __var value      = 0;
     
       // Enable Reset Vector Catch in DEMCR
-      __value = Read32(__DEMCR_Addr);
-      Write32(__DEMCR_Addr, (__value | 0x00000001));
+      value = Read32(DEMCR_Addr);
+      Write32(DEMCR_Addr, (value | 0x00000001));
 
       // Read DHCSR to clear potentially set DHCSR.S_RESET_ST bit
-      Read32(__DHCSR_Addr);
+      Read32(DHCSR_Addr);
     </block>
   
   </sequence>
@@ -793,13 +793,13 @@ Free hardware resources allocated by ResetCatchSet.
       // in Armv6-M/Armv7-M. Reimplement this sequence
       // if the SCS is located at a different offset.
       
-      __var __SCS_Addr   = 0xE000E000;
-      __var __DEMCR_Addr = __SCS_Addr + 0xDFC;
-      __var __value      = 0;
+      __var SCS_Addr   = 0xE000E000;
+      __var DEMCR_Addr = SCS_Addr + 0xDFC;
+      __var value      = 0;
       
       // Disable Reset Vector Catch in DEMCR
-      __value = Read32(__DEMCR_Addr);
-      Write32(__DEMCR_Addr, (__value &amp; (~0x00000001)));
+      value = Read32(DEMCR_Addr);
+      Write32(DEMCR_Addr, (value &amp; (~0x00000001)));
     </block>
     
   </sequence>
@@ -1920,10 +1920,12 @@ and states. They are <b>read-only</b> within a sequence except from a limited se
 \ref PredefinedDebugVars "pre-defined debug access variables". Use the <b>debugvars</b> element to specify additional
 user-defined debug access variables.
 
-User-defined debug access variable names must not be reused for local sequence variables, including those in default
-sequence implementations. To avoid name clashes, the \token{__} prefix is reserved for variables provided by the
-specification (for example, in default sequence implementations). User-defined debug access variables should avoid
-using the \token{__} prefix.
+User-defined debug access variable names must not be reused for local sequence variables. To avoid name clashes,
+pre-defined debug access variables and local variables used by debugger-provided default sequence implementations
+should use the \token{__} prefix. Local variables in DFP-provided sequences should not use the \token{__} prefix,
+including when a DFP copies and adapts a default sequence shown in this specification. If a debugger
+implementation copies a default sequence from this specification, it should add the \token{__} prefix to
+local variable names.
 
 \anchor PredefinedDebugVars <b>Table: Pre-defined Debug Access Variables</b><br>
 A debugger needs to support a set of pre-defined debug access variables. These are described in the following table.

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -3064,8 +3064,8 @@ The table lists the values for debug protocol types. The values can be used in
 \section element_debugvars /package/devices/family/.../debugvars
 
 Specify \ref DebugVars "global debug access variables". Use these in addition 
-to the \ref PredefinedDebugVars "pre-defined variables" in order to
-query settings from a debug access sequences.<br>
+to the \ref PredefinedDebugVars "pre-defined variables" to pass user settings
+to debug access sequences.<br>
 <br>
 Define debug access variables with statements of the following form.
 \code
@@ -3076,6 +3076,8 @@ __var uservar = value;  // Comment: Define "uservar" and initialize to "value"
 - Initialization values must be constant unsigned numbers. No expressions are allowed.
 - User-defined debug access variables are <b>read-only</b> in a debug access sequence.
 - Pre-defined debug access variables cannot be set in this element.
+- The \token{__} prefix is reserved for variables provided by the specification and should
+  not be used for user-defined debug access variables.
 
 \b Example
 \code
@@ -3084,16 +3086,16 @@ __var uservar = value;  // Comment: Define "uservar" and initialize to "value"
   ...
   <debugvars configfile="Debug/EFM32WGxxx.dbgconf" version="1.0">
   
-    __var __TPIU_pinlocation = 0;  // Select one of four possible TPIU pin locations
+    __var TPIU_pinlocation = 0;  // Select one of four possible TPIU pin locations
     
-    __var __SWO_pinlocation  = 0;  // Select one of four possible SWO pin locations
+    __var SWO_pinlocation  = 0;  // Select one of four possible SWO pin locations
     
   </debugvars>
   ...
   <sequences>
     <sequence name="TraceStart">
       ...
-      <block if="__TPIU_pinlocation == 2">
+      <block if="TPIU_pinlocation == 2">
         ...
         <!-- Configure device to use pins as defined for TPIU pin location 2 -->
         ...
@@ -3179,7 +3181,7 @@ __var uservar = value;  // Comment: Define "uservar" and initialize to "value"
 // <i> - Pin Location 2 (TRACECLK: PC6, TRACEDATA0: PC7, TRACEDATA1: PD3,  TRACEDATA2: PD4,  TRACEDATA3: PD5)
 // <i> - Pin Location 3 (TRACECLK: PA6, TRACEDATA0: PA2, TRACEDATA1: PA3,  TRACEDATA2: PA4,  TRACEDATA3: PA5)
 // <i> Default: Pin Location 0
-__TPIU_pinlocation = 0;
+TPIU_pinlocation = 0;
   
 // <o> SWO Pin Location
 //   <0=> Pin Location 0
@@ -3192,7 +3194,7 @@ __TPIU_pinlocation = 0;
 // <i> - Pin Location 2 (SWO: PD1)
 // <i> - Pin Location 3 (SWO: PD2)
 // <i> Default: Pin Location 0
-__SWO_pinlocation = 0;
+SWO_pinlocation = 0;
   
 // </h>
 // <<< end of configuration section >>>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -3076,8 +3076,11 @@ __var uservar = value;  // Comment: Define "uservar" and initialize to "value"
 - Initialization values must be constant unsigned numbers. No expressions are allowed.
 - User-defined debug access variables are <b>read-only</b> in a debug access sequence.
 - Pre-defined debug access variables cannot be set in this element.
-- The \token{__} prefix is reserved for variables provided by the specification and should
-  not be used for user-defined debug access variables.
+- The \token{__} prefix is used for pre-defined debug access variables and for local
+  variables in debugger-provided default sequence implementations. It should not be used
+  for user-defined debug access variables or for local variables in DFP-provided sequences.
+  If a debugger implementation copies a default sequence shown in this specification, it
+  should add the \token{__} prefix to the local variable names.
 
 \b Example
 \code


### PR DESCRIPTION
Addresses #392 

Changes:
- adds rules to reserve `__` prefix for debug access variable names provided by spec
- added '__' prefix to variable names in default debug sequence implementations
- fixed some other wording

To discuss:
Examples previously used `__` for local variables in user sequences. They have been changed but some ended in published packs. Hence the rules talk about "should", not "must".