### PR TITLE
Trace configuration updates

### DIFF
--- a/doxygen/pack.dxy
+++ b/doxygen/pack.dxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Open-CMSIS-Pack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Version 1.7.58"
+PROJECT_NUMBER         = "Version 1.7.59"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -85,6 +85,8 @@ packs) and provides useful tips when creating a pack.
     <td>
       - clarified sequence abortion in case of errors
       - added missing ResetCatchClear to debug connect flow diagram
+      - added pre-defined 'TraceCapture' and 'TraceFlush' debug access sequences
+      - added pre-defined '__traceclockin' and '__traceclockout' debug access variables
     </td>
   </tr>
   <tr>

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -81,12 +81,13 @@ packs) and provides useful tips when creating a pack.
     <th>Description</th>
   </tr>
   <tr>
-    <td>next</td>
+    <td>1.7.59</td>
     <td>
       - clarified sequence abortion in case of errors
       - added missing ResetCatchClear to debug connect flow diagram
       - added pre-defined 'TraceCapture' and 'TraceFlush' debug access sequences
       - added pre-defined '__traceclockin' and '__traceclockout' debug access variables
+      - adds 'fullTraceSetup' attribute to 'sequences' element
     </td>
   </tr>
   <tr>

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -87,7 +87,7 @@ packs) and provides useful tips when creating a pack.
       - added missing ResetCatchClear to debug connect flow diagram
       - added pre-defined 'TraceCapture' and 'TraceFlush' debug access sequences
       - added pre-defined '__traceclockin' and '__traceclockout' debug access variables
-      - added 'fullTraceSetup' attribute to 'sequences' element
+      - added 'traceSetup' attribute to 'sequences' element
     </td>
   </tr>
   <tr>

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -87,7 +87,7 @@ packs) and provides useful tips when creating a pack.
       - added missing ResetCatchClear to debug connect flow diagram
       - added pre-defined 'TraceCapture' and 'TraceFlush' debug access sequences
       - added pre-defined '__traceclockin' and '__traceclockout' debug access variables
-      - adds 'fullTraceSetup' attribute to 'sequences' element
+      - added 'fullTraceSetup' attribute to 'sequences' element
     </td>
   </tr>
   <tr>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -265,7 +265,6 @@ For debug access sequences marked in \token{ItalicRed}, no default implementatio
 	\anchor TraceCapture
     <td>Prepare target trace for next capture run, e.g. by enabling the trace formatter or initializing embedded trace buffer data read/write pointers.<br>
     Typically executed before a debugger runs/steps the target processor. Or when manually starting a trace capture.<br>
-	TODO: Add an example.
     </td>
   </tr>
   <tr>
@@ -273,7 +272,6 @@ For debug access sequences marked in \token{ItalicRed}, no default implementatio
 	\anchor TraceFlush
     <td>Flush out remaining trace bytes. This ensures all pending data is streamed off-chip, or drained into an on-chip trace buffer before the debugger reads it.<br>
     Typically executed after the target processor pauses after a run/step. Or when manually stopping a trace capture.<br>
-	TODO: Add an example.
     </td>
   </tr>
   <tr>
@@ -2075,7 +2073,7 @@ A debugger needs to support a set of pre-defined debug access variables. These a
 	<pre>__traceclockin</pre></td>
     <td>Read-Only</td>
     <td>
-      The frequency of the clock that drives the trace output component.<br/>
+      The frequency of the clock that drives the trace output component.<br>
       Can for example be used in combination with \ref __traceclockout to calculate
       prescaler values for the output component.
     </td>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -106,7 +106,7 @@ The table below lists the available predefined debug access sequences. Their def
 
 For debug access sequences marked in \token{ItalicRed}, no default implementation  exists. When using them in debug descriptions corresponding user implementation shall be done as well. 
 
-\note Predefined debug access sequences read the System Control Space (SCS) of the processor and assume that the SCS offset is implemented as defined in the Armv6-M/Armv7-M/Armv8-M architecture reference manual.
+\note Predefined debug access sequences read the System Control Space (SCS) of the processor and assume that the SCS base address is implemented as defined in the Armv6-M/Armv7-M/Armv8-M architecture reference manual.
 
 <table class="cmtable" summary="Enumeration: SequenceNameEnum">
   <tr>
@@ -258,6 +258,22 @@ For debug access sequences marked in \token{ItalicRed}, no default implementatio
 	\anchor TraceStop
     <td>Disable target trace capture.<br>
     Executed after the debugger disabled and powered down standard CoreSight trace components.
+    </td>
+  </tr>
+  <tr>
+    <td class="XML-Token">TraceCapture</td>
+	\anchor TraceCapture
+    <td>Prepare target trace for next capture run, e.g. by enabling the trace formatter or initializing embedded trace buffer data read/write pointers.<br>
+    Typically executed before a debugger runs/steps the target processor. Or when manually starting a trace capture.<br>
+	TODO: Add an example.
+    </td>
+  </tr>
+  <tr>
+    <td class="XML-Token">TraceFlush</td>
+	\anchor TraceFlush
+    <td>Flush out remaining trace bytes. This ensures all pending data is streamed off-chip, or drained into an on-chip trace buffer before the debugger reads it.<br>
+    Typically executed after the target processor pauses after a run/step. Or when manually stopping a trace capture.<br>
+	TODO: Add an example.
     </td>
   </tr>
   <tr>
@@ -2051,6 +2067,35 @@ A debugger needs to support a set of pre-defined debug access variables. These a
       - Bit 3..15: Reserved.
       - Bit 16..21: Selected Parallel Trace Port size.
       - Bit 22..63: Reserved.
+    </td>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">
+	\anchor __traceclockin
+	<pre>__traceclockin</pre></td>
+    <td>Read-Only</td>
+    <td>
+      The frequency of the clock that drives the trace output component.<br/>
+      Can for example be used in combination with \ref __traceclockout to calculate
+      prescaler values for the output component.
+    </td>
+    <td>
+      Clock frequency in Hz. A value of \token{0} means that the frequency is not set by the debugger.
+    </td>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">
+	\anchor __traceclockout
+	<pre>__traceclockout</pre></td>
+    <td>Read-Only</td>
+    <td>
+      The frequency of the trace output signal.<br>
+      Can for example be used in combination with \ref __traceclockin to calculate prescaler
+      values for the output component.
+    </td>
+    <td>
+      Clock frequency in Hz. A value of \token{0} means that the frequency is not set by the debugger.
+      In this case <b>__traceclockout</b> must be assumed to equal \ref __traceclockin .
     </td>
   </tr>
   <tr>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -248,10 +248,10 @@ For debug access sequences marked in \token{ItalicRed}, no default implementatio
     <td class="XML-Token">TraceStart</td>
 	\anchor TraceStart
     <td>Enable target trace capture.<br>
-    If \refelem{sequences} specifies <b>fullTraceSetup=\token{false}</b> or omits the attribute,
+    If \refelem{sequences} specifies <b>traceSetup=\token{legacy}</b> or omits the attribute,
     this sequence is executed before the debugger powers up and configures standard CoreSight trace
     components, e.g. after the initial target connection as well as after a system-wide reset.<br>
-	If \refelem{sequences} specifies <b>fullTraceSetup=\token{true}</b>, this sequence is expected
+	If \refelem{sequences} specifies <b>traceSetup=\token{full}</b>, this sequence is expected
 	to perform all trace sink and trace data path setup required by the device, and the debugger is
 	not expected to configure standard CoreSight trace components using a priori knowledge.<br>
 	See example at \ref userTraceStart.
@@ -261,10 +261,10 @@ For debug access sequences marked in \token{ItalicRed}, no default implementatio
     <td class="XML-Token">TraceStop</td>
 	\anchor TraceStop
     <td>Disable target trace capture.<br>
-    If \refelem{sequences} specifies <b>fullTraceSetup=\token{false}</b> or omits the attribute,
+    If \refelem{sequences} specifies <b>traceSetup=\token{legacy}</b> or omits the attribute,
     this sequence is executed after the debugger disabled and powered down standard CoreSight trace
     components.<br>
-	If \refelem{sequences} specifies <b>fullTraceSetup=\token{true}</b>, this sequence is expected
+	If \refelem{sequences} specifies <b>traceSetup=\token{full}</b>, this sequence is expected
 	to perform all trace sink and trace data path shutdown steps required by the device.
     </td>
   </tr>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -248,8 +248,12 @@ For debug access sequences marked in \token{ItalicRed}, no default implementatio
     <td class="XML-Token">TraceStart</td>
 	\anchor TraceStart
     <td>Enable target trace capture.<br>
-    Executed before the debugger powers up and configures standard CoreSight trace components, e.g. after the initial target connection
-    as well as after a system-wide reset.<br>
+    If \refelem{sequences} specifies <b>fullTraceSetup=\token{false}</b> or omits the attribute,
+    this sequence is executed before the debugger powers up and configures standard CoreSight trace
+    components, e.g. after the initial target connection as well as after a system-wide reset.<br>
+	If \refelem{sequences} specifies <b>fullTraceSetup=\token{true}</b>, this sequence is expected
+	to perform all trace sink and trace data path setup required by the device, and the debugger is
+	not expected to configure standard CoreSight trace components using a priori knowledge.<br>
 	See example at \ref userTraceStart.
     </td>
   </tr>
@@ -257,7 +261,11 @@ For debug access sequences marked in \token{ItalicRed}, no default implementatio
     <td class="XML-Token">TraceStop</td>
 	\anchor TraceStop
     <td>Disable target trace capture.<br>
-    Executed after the debugger disabled and powered down standard CoreSight trace components.
+    If \refelem{sequences} specifies <b>fullTraceSetup=\token{false}</b> or omits the attribute,
+    this sequence is executed after the debugger disabled and powered down standard CoreSight trace
+    components.<br>
+	If \refelem{sequences} specifies <b>fullTraceSetup=\token{true}</b>, this sequence is expected
+	to perform all trace sink and trace data path shutdown steps required by the device.
     </td>
   </tr>
   <tr>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -249,11 +249,11 @@ For debug access sequences marked in \token{ItalicRed}, no default implementatio
 	\anchor TraceStart
     <td>Enable target trace capture.<br>
     If \refelem{sequences} specifies <b>traceSetup=\token{legacy}</b> or omits the attribute,
-    this sequence is executed before the debugger powers up and configures standard CoreSight trace
+    this sequence is executed before the debugger powers up and configures CoreSight trace
     components, e.g. after the initial target connection as well as after a system-wide reset.<br>
 	If \refelem{sequences} specifies <b>traceSetup=\token{full}</b>, this sequence is expected
 	to perform all trace sink and trace data path setup required by the device, and the debugger is
-	not expected to configure standard CoreSight trace components using a priori knowledge.<br>
+	not expected to configure CoreSight trace components using a priori knowledge.<br>
 	See example at \ref userTraceStart.
     </td>
   </tr>
@@ -262,7 +262,7 @@ For debug access sequences marked in \token{ItalicRed}, no default implementatio
 	\anchor TraceStop
     <td>Disable target trace capture.<br>
     If \refelem{sequences} specifies <b>traceSetup=\token{legacy}</b> or omits the attribute,
-    this sequence is executed after the debugger disabled and powered down standard CoreSight trace
+    this sequence is executed after the debugger disabled and powered down CoreSight trace
     components.<br>
 	If \refelem{sequences} specifies <b>traceSetup=\token{full}</b>, this sequence is expected
 	to perform all trace sink and trace data path shutdown steps required by the device.

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -249,8 +249,8 @@ For debug access sequences marked in \token{ItalicRed}, no default implementatio
 	\anchor TraceStart
     <td>Enable target trace capture.<br>
     If \refelem{sequences} specifies <b>traceSetup=\token{legacy}</b> or omits the attribute,
-    this sequence is executed before the debugger powers up and configures CoreSight trace
-    components, e.g. after the initial target connection as well as after a system-wide reset.<br>
+    this sequence is executed before the debugger configures CoreSight trace components, e.g. after
+    the initial target connection as well as after a system-wide reset.<br>
 	If \refelem{sequences} specifies <b>traceSetup=\token{full}</b>, this sequence is expected
 	to perform all trace sink and trace data path setup required by the device, and the debugger is
 	not expected to configure CoreSight trace components using a priori knowledge.<br>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -2080,7 +2080,7 @@ A debugger needs to support a set of pre-defined debug access variables. These a
       prescaler values for the output component.
     </td>
     <td>
-      Clock frequency in Hz. A value of \token{0} means that the frequency is not set by the debugger.
+      Clock frequency in Hz. A value of \token{0} means that no frequency is provided by the debugger, e.g. because trace is disabled.
     </td>
   </tr>
   <tr>
@@ -2094,8 +2094,8 @@ A debugger needs to support a set of pre-defined debug access variables. These a
       values for the output component.
     </td>
     <td>
-      Clock frequency in Hz. A value of \token{0} means that the frequency is not set by the debugger.
-      In this case <b>__traceclockout</b> must be assumed to equal \ref __traceclockin .
+      Clock frequency in Hz. A value of \token{0} means that no frequency is provided by the debugger, e.g. because trace is disabled or because the user did not specify it.
+      In the latter case <b>__traceclockout</b> must be assumed to equal \ref __traceclockin which effectively means a prescaler value of \token{1}.
     </td>
   </tr>
   <tr>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -3709,7 +3709,7 @@ Container for debug access sequences for this device.
 \code
 <family Dfamily="LPC4300 Series" Dvendor="NXP:11">
   ...
-  <sequences>
+  <sequences fullTraceSetup="false">
     ...
     <sequence name="DebugCoreStart" Pname="Cortex-M0">
       ...
@@ -3745,6 +3745,30 @@ Container for debug access sequences for this device.
   <tr>
     <td>\ref element_device "device"</td>
     <td colspan="3">\ref element_device</td>
+  </tr>
+  <tr>
+    <th>Attributes</th>
+    <th>Description</th>
+    <th>Type</th>
+    <th>Use</th>
+  </tr>
+  <tr>
+    <td>fullTraceSetup</td>
+    <td>
+      If <b>true</b>, all trace sink and trace data path setup is done by debug access sequences.
+      In this case, a debugger is not expected to configure trace sinks or the CoreSight trace
+      data path using a priori knowledge of standard CoreSight components.<br>
+      <br>
+      If <b>false</b>, a debugger is expected to have knowledge of standard CoreSight trace
+      components. In this case, the <b>TraceStart</b> and <b>TraceStop</b> sequences are intended
+      only for device-specific trace setup and teardown steps.<br>
+      <br>
+      Default value is \token{false}. However, the expectation is that future DFPs set it to \token{true}
+      and provide the full trace setup in sequences. The default value will change with the next
+      major version update of this specification.
+    </td>
+    <td>xs:boolean</td>
+    <td>optional</td>
   </tr>
   <tr>
     <th>Child&nbsp;Elements</th>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -3709,7 +3709,7 @@ Container for debug access sequences for this device.
 \code
 <family Dfamily="LPC4300 Series" Dvendor="NXP:11">
   ...
-  <sequences fullTraceSetup="false">
+  <sequences traceSetup="legacy">
     ...
     <sequence name="DebugCoreStart" Pname="Cortex-M0">
       ...
@@ -3753,17 +3753,17 @@ Container for debug access sequences for this device.
     <th>Use</th>
   </tr>
   <tr>
-    <td>fullTraceSetup</td>
+    <td>traceSetup</td>
     <td>
-      If <b>true</b>, all trace sink and trace data path setup is done by debug access sequences.
+      If <b>full</b>, all trace sink and trace data path setup is done by debug access sequences.
       In this case, a debugger is not expected to configure trace sinks or the CoreSight trace
       data path using a priori knowledge of standard CoreSight components.<br>
       <br>
-      If <b>false</b>, a debugger is expected to have knowledge of standard CoreSight trace
+      If <b>legacy</b>, a debugger is expected to have knowledge of standard CoreSight trace
       components. In this case, the <b>TraceStart</b> and <b>TraceStop</b> sequences are intended
       only for device-specific trace setup and teardown steps.<br>
       <br>
-      Default value is \token{false}. However, the expectation is that future DFPs set it to \token{true}
+      Default value is \token{legacy}. However, the expectation is that future DFPs set it to \token{full}
       and provide the full trace setup in sequences. The default value will change with the next
       major version update of this specification.
     </td>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -3757,9 +3757,9 @@ Container for debug access sequences for this device.
     <td>
       If <b>full</b>, all trace sink and trace data path setup is done by debug access sequences.
       In this case, a debugger is not expected to configure trace sinks or the CoreSight trace
-      data path using a priori knowledge of standard CoreSight components.<br>
+      data path using a priori knowledge of CoreSight trace components.<br>
       <br>
-      If <b>legacy</b>, a debugger is expected to have knowledge of standard CoreSight trace
+      If <b>legacy</b>, a debugger is expected to have knowledge of CoreSight trace
       components. In this case, the <b>TraceStart</b> and <b>TraceStop</b> sequences are intended
       only for device-specific trace setup and teardown steps.<br>
       <br>

--- a/doxygen/src/pack_dbg_setup_tutorial.txt
+++ b/doxygen/src/pack_dbg_setup_tutorial.txt
@@ -238,7 +238,7 @@ A common case that requires use of debug access sequences is trace configuration
 
 By default these sequences are empty and often need to be implemented in the .pdsc file to support device-specific behavior, for example to differentiate configuration for 1-pin SWO trace and 5-pin ETM trace (TPIU).
 
-If the parent \ref element_sequences "sequences" element specifies <b>fullTraceSetup=\token{true}</b>,
+If the parent \ref element_sequences "sequences" element specifies <b>traceSetup=\token{full}</b>,
 the trace-related debug access sequences are expected to perform the complete trace sink and trace data
 path setup and shutdown, rather than only device-specific additions to debugger-provided CoreSight handling.
 

--- a/doxygen/src/pack_dbg_setup_tutorial.txt
+++ b/doxygen/src/pack_dbg_setup_tutorial.txt
@@ -238,6 +238,10 @@ A common case that requires use of debug access sequences is trace configuration
 
 By default these sequences are empty and often need to be implemented in the .pdsc file to support device-specific behavior, for example to differentiate configuration for 1-pin SWO trace and 5-pin ETM trace (TPIU).
 
+If the parent \ref element_sequences "sequences" element specifies <b>fullTraceSetup=\token{true}</b>,
+the trace-related debug access sequences are expected to perform the complete trace sink and trace data
+path setup and shutdown, rather than only device-specific additions to debugger-provided CoreSight handling.
+
 For example:
 
 \code

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -26,7 +26,7 @@
   SchemaVersion=1.7.59
 
   26. Jun 2026: v1.7.59
-   - added 'fullTraceSetup' attribute to 'sequences' element
+   - added 'traceSetup' attribute to 'sequences' element
   15. Jun 2026: v1.7.58
    - added Dvendor ID "ESMT:190" for Elite Semiconductor Microelectronics Technology Inc..
   04. Mar 2026: v1.7.57
@@ -754,12 +754,20 @@
     <xs:anyAttribute processContents="lax" />
   </xs:complexType>
 
+  <!-- TraceSetupEnum enumeration type -->
+  <xs:simpleType name="TraceSetupEnum">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="full" />
+      <xs:enumeration value="legacy" />
+    </xs:restriction>
+  </xs:simpleType>
+
   <!-- SequencesType -->
   <xs:complexType name="SequencesType">
     <xs:sequence>
       <xs:element name="sequence" type="SequenceType" minOccurs="1" maxOccurs="unbounded" />
     </xs:sequence>
-    <xs:attribute name="fullTraceSetup" type="xs:boolean" use="optional" default="false" />
+    <xs:attribute name="traceSetup" type="TraceSetupEnum" use="optional" default="legacy" />
     <xs:anyAttribute processContents="lax" />
   </xs:complexType>
 

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -273,7 +273,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.58">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.59">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -26,7 +26,7 @@
   SchemaVersion=1.7.59
 
   26. Jun 2026: v1.7.59
-   - adds 'fullTraceSetup' attribute to 'sequences' element
+   - added 'fullTraceSetup' attribute to 'sequences' element
   15. Jun 2026: v1.7.58
    - added Dvendor ID "ESMT:190" for Elite Semiconductor Microelectronics Technology Inc..
   04. Mar 2026: v1.7.57

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -18,13 +18,15 @@
   limitations under the License.
 
 
-  $Date:        15. June 2026
-  $Revision:    1.7.58
+  $Date:        26. June 2026
+  $Revision:    1.7.59
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
-  SchemaVersion=1.7.58
+  SchemaVersion=1.7.59
 
+  26. Jun 2026: v1.7.59
+   - adds 'fullTraceSetup' attribute to 'sequences' element
   15. Jun 2026: v1.7.58
    - added Dvendor ID "ESMT:190" for Elite Semiconductor Microelectronics Technology Inc..
   04. Mar 2026: v1.7.57
@@ -757,6 +759,7 @@
     <xs:sequence>
       <xs:element name="sequence" type="SequenceType" minOccurs="1" maxOccurs="unbounded" />
     </xs:sequence>
+    <xs:attribute name="fullTraceSetup" type="xs:boolean" use="optional" default="false" />
     <xs:anyAttribute processContents="lax" />
   </xs:complexType>
 


### PR DESCRIPTION
Addresses part of https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/581
Complements https://github.com/Open-CMSIS-Pack/cmsis-toolbox/pull/586

- Adds `TraceCapture` and `TraceFlush` sequences to prepare/complete a trace capture run.
- Adds `__traceclockin` and `__traceclockout` debug access variables to transport user trace clock settings into debug sequences.
- Adds `traceSetup` attribute to `sequences` element
