### PR TITLE
Add debug sequence support for Python scripts and runtime flash algorithm selection

### DIFF
--- a/doxygen/pack.dxy
+++ b/doxygen/pack.dxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Open-CMSIS-Pack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Version 1.7.59"
+PROJECT_NUMBER         = "Version 1.7.60"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -81,6 +81,12 @@ packs) and provides useful tips when creating a pack.
     <th>Description</th>
   </tr>
   <tr>
+    <td>1.7.60</td>
+    <td>
+      - added 'RunPythonScript' debug access function
+    </td>
+  </tr>
+  <tr>
     <td>1.7.59</td>
     <td>
       - clarified sequence abortion in case of errors

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -83,6 +83,7 @@ packs) and provides useful tips when creating a pack.
   <tr>
     <td>1.7.60</td>
     <td>
+      - added 'FlashEraseSetup' and 'FlashProgramSetup' debug access sequences
       - added 'FlashLoadAlgorithm' debug access function
       - added 'RunPythonScript' debug access function
     </td>

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -83,6 +83,7 @@ packs) and provides useful tips when creating a pack.
   <tr>
     <td>1.7.60</td>
     <td>
+      - added 'FlashLoadAlgorithm' debug access function
       - added 'RunPythonScript' debug access function
     </td>
   </tr>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -1954,6 +1954,28 @@ debug access variables which are evaluated for the function call.
         Refer to \ref exttoolexample "Calculating a hash sum"
     </td>
   </tr>
+  <tr>
+    <td style="white-space: nowrap"><pre>FlashLoadAlgorithm(algoPath, ramStart, ramSize)</pre></td>
+    <td>
+      Select an FLM flash algorithm for the current flash erase or program phase. This function is valid only in a
+      <b>FlashEraseSetup</b> or <b>FlashProgramSetup</b> sequence. The selected algorithm is loaded by the debugger when
+      the corresponding phase is performed.<br>
+      <br>
+      <b>Parameters:</b><br>
+      - algoPath: Constant string representing the path to an FLM file. Refer to \ref charactersequence "character sequences"
+        for path/file name place holders.
+      - ramStart: Start address of target RAM available to the FLM algorithm. The address must be in a defined RAM region.
+      - ramSize: Size, in bytes, of target RAM available to the FLM algorithm. If the range extends beyond the containing
+        RAM region, the debugger limits it to the available RAM.
+
+      <b>Return Value:</b><br>
+      \token{0} - Flash algorithm selected successfully.<br>
+      \token{1} - Flash algorithm could not be selected.<br>
+      <br>
+      If this function returns \token{1}, the current erase or program phase fails. It does not fall back to flash debug
+      sequences.
+    </td>
+  </tr>
 </table>
 
 \note

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -1003,10 +1003,11 @@ This section provides examples of user-implemented predefined debug access seque
 
 \subsection flashAlgorithmSelection Selecting an FLM algorithm for flash operations
 
-The optional \b FlashEraseSetup and \b FlashProgramSetup sequences can select an FLM algorithm for an erase or program
-phase. The debugger provides \b __FlashAddr and \b __FlashLen to identify the requested address range. The following
-examples select an FLM only when the complete range is within the external flash region. When the condition is false, the
-corresponding operation uses the flash debug sequences.
+The optional \b FlashEraseSetup and \b FlashProgramSetup sequences are evaluated only for erase and program phases associated
+with \ref element_flashinfo "flashinfo" regions. They are not used when the target defines no \b flashinfo regions. The sequences
+can select an FLM algorithm for an erase or program phase. The debugger provides \b __FlashAddr and \b __FlashLen to identify the
+requested address range. The following examples select an FLM only when the complete range is within the external flash region.
+When the condition is false, the corresponding operation uses the flash debug sequences.
 
 \subsubsection flashEraseSetupExample FlashEraseSetup example
 

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -203,6 +203,22 @@ For debug access sequences marked in \token{ItalicRed}, no default implementatio
     </td>
   </tr>
   <tr>
+    <td class="XML-Token">FlashEraseSetup</td>
+    <td>
+    Optional setup before an erase phase for a \ref element_flashinfo "flashinfo" region. The sequence can call
+    <b>FlashLoadAlgorithm</b> to select an FLM flash algorithm for the erase phase. If the sequence is not implemented or
+    does not select an algorithm, the debugger uses the flash debug sequences for erase.
+    </td>
+  </tr>
+  <tr>
+    <td class="XML-Token">FlashProgramSetup</td>
+    <td>
+    Optional setup before a program phase for a \ref element_flashinfo "flashinfo" region. The sequence can call
+    <b>FlashLoadAlgorithm</b> to select an FLM flash algorithm for the program phase. If the sequence is not implemented or
+    does not select an algorithm, the debugger uses the flash debug sequences for programming.
+    </td>
+  </tr>
+  <tr>
     <td class="XML-Token">FlashInit</td>
     <td>
     Executed before starting a flash operation.
@@ -982,6 +998,41 @@ This section provides examples of user-implemented predefined debug access seque
   </block>
 </control>
 ...
+\endcode
+
+
+\subsection flashAlgorithmSelection Selecting an FLM algorithm for flash operations
+
+The optional \b FlashEraseSetup and \b FlashProgramSetup sequences can select an FLM algorithm for an erase or program
+phase. The debugger provides \b __FlashAddr and \b __FlashLen to identify the requested address range. The following
+examples select an FLM only when the complete range is within the external flash region. When the condition is false, the
+corresponding operation uses the flash debug sequences.
+
+\subsubsection flashEraseSetupExample FlashEraseSetup example
+
+\code
+<sequence name="FlashEraseSetup">
+  <control if="(__FlashAddr &gt;= 0x60000000) &amp;&amp; ((__FlashAddr + __FlashLen) &lt;= 0x61000000)"
+           info="Select FLM for external flash erase">
+    <block>
+      FlashLoadAlgorithm("$S/Flash/ExternalFlash.FLM", 0x20000000, 0x00008000);
+    </block>
+  </control>
+</sequence>
+\endcode
+
+
+\subsubsection flashProgramSetupExample FlashProgramSetup example
+
+\code
+<sequence name="FlashProgramSetup">
+  <control if="(__FlashAddr &gt;= 0x60000000) &amp;&amp; ((__FlashAddr + __FlashLen) &lt;= 0x61000000)"
+           info="Select FLM for external flash programming">
+    <block>
+      FlashLoadAlgorithm("$S/Flash/ExternalFlash.FLM", 0x20000000, 0x00008000);
+    </block>
+  </control>
+</sequence>
 \endcode
 
 

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -1913,6 +1913,25 @@ debug access variables which are evaluated for the function call.
     </td>
   </tr>
   <tr>
+    <td style="white-space: nowrap"><pre>RunPythonScript (scriptPath, arguments, workDirectory, timeout)</pre></td>
+    <td>
+        Run a Python script using a Python interpreter available on the host system.<br>
+        <br>
+        <b>Parameters:</b><br>
+        - scriptPath: Constant string representing the Python script path. Refer to \ref charactersequence "character sequences"
+          for path/file name place holders.
+        - arguments: Constant string with arguments to pass to the script command line. Same placeholder
+          \ref charactersequence "character sequences" apply as for <b>scriptPath</b>.
+        - workDirectory: A constant string with the work directory for running the script. An empty string means that the
+          work directory is the current project folder. Same placeholder \ref charactersequence "character sequences" apply
+          as for <b>scriptPath</b>.
+        - timeout: Timeout in microseconds.
+
+        <b>Return Value:</b><br>
+        Script specific exit code.
+    </td>
+  </tr>
+  <tr>
     <td style="white-space: nowrap"><pre>FilePathExists(path, timeout)</pre></td>
     <td>
         Check if a path exists. If timeout is other than \token{0} then check the path until it becomes valid or until the
@@ -2194,8 +2213,8 @@ A debugger needs to support a set of pre-defined debug access variables. These a
 Some functionality cannot be implemented by debug sequences, for example checksum/hash calculations or debug authentication.
 It is supposed to be provided or implemented by external tools or applications. To communicate with external tools, debug
 sequences currently provide input/output files. To create these files, buffers are used (see below). To run an external
-application, use the \c RunApplication function. To check the availability of an external resource (for example a file), use
-the \c FilePathExists function.
+application, use the \c RunApplication function. To run a Python script, use the \c RunPythonScript function. To check the
+availability of an external resource (for example a file), use the \c FilePathExists function.
 
 \b Buffer \b handling
 

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -18,13 +18,15 @@
   limitations under the License.
 
 
-  $Date:        26. June 2026
-  $Revision:    1.7.59
+  $Date:        22. July 2026
+  $Revision:    1.7.60
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
-  SchemaVersion=1.7.59
+  SchemaVersion=1.7.60
 
+  22. Jul 2026: v1.7.60
+   - added 'RunPythonScript' debug access function
   26. Jun 2026: v1.7.59
    - added 'traceSetup' attribute to 'sequences' element
   15. Jun 2026: v1.7.58
@@ -273,7 +275,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.59">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.60">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -26,6 +26,7 @@
   SchemaVersion=1.7.60
 
   22. Jul 2026: v1.7.60
+   - added 'FlashEraseSetup' and 'FlashProgramSetup' debug access sequences
    - added 'FlashLoadAlgorithm' debug access function
    - added 'RunPythonScript' debug access function
   26. Jun 2026: v1.7.59

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -26,6 +26,7 @@
   SchemaVersion=1.7.60
 
   22. Jul 2026: v1.7.60
+   - added 'FlashLoadAlgorithm' debug access function
    - added 'RunPythonScript' debug access function
   26. Jun 2026: v1.7.59
    - added 'traceSetup' attribute to 'sequences' element


### PR DESCRIPTION
Complements:
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/948
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/1013

Changes:
- Adds the `RunPythonScript` debug access function.
- Adds the `FlashEraseSetup` and `FlashProgramSetup` debug access sequences.
- Adds the `FlashLoadAlgorithm` debug access function for selecting an FLM algorithm for a flash operation.
- Adds examples that select an FLM based on `__FlashAddr` and `__FlashLen`.