### PR TITLE
Clarifications about sequence based and FLM based flash programming

### DIFF
--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -108,6 +108,14 @@ For debug access sequences marked in \token{ItalicRed}, no default implementatio
 
 \note Predefined debug access sequences read the System Control Space (SCS) of the processor and assume that the SCS base address is implemented as defined in the Armv6-M/Armv7-M/Armv8-M architecture reference manual.
 
+\note The \b FlashInit, \b FlashUninit, \b FlashEraseSector, \b FlashEraseChip, and \b FlashProgramPage sequences are the
+sequence-based counterparts of the corresponding FLM functions. They require a corresponding
+\ref element_flashinfo "flashinfo" region, which supplies the memory layout and programming parameters. \b FlashEraseSetup and
+\b FlashProgramSetup can select an FLM algorithm instead of these sequences for an erase or program phase. A target may define
+one or more \b flashinfo regions without implementing any flash debug sequences; in that case all such regions are ignored.
+\b FlashEraseDone and \b FlashProgramDone are completion callbacks and are also executed when an FLM flash algorithm performs
+the erase or program operation.
+
 <table class="cmtable" summary="Enumeration: SequenceNameEnum">
   <tr>
     <th>name=</th>
@@ -206,58 +214,64 @@ For debug access sequences marked in \token{ItalicRed}, no default implementatio
     <td class="XML-Token">FlashEraseSetup</td>
     <td>
     Optional setup before an erase phase for a \ref element_flashinfo "flashinfo" region. The sequence can call
-    <b>FlashLoadAlgorithm</b> to select an FLM flash algorithm for the erase phase. If the sequence is not implemented or
-    does not select an algorithm, the debugger uses the flash debug sequences for erase.
+    <b>FlashLoadAlgorithm</b> to select an FLM flash algorithm for the erase phase. The debugger then uses the FLM functions
+    instead of the corresponding flash debug sequences. If no algorithm is selected, the debugger uses the flash debug sequences.
     </td>
   </tr>
   <tr>
     <td class="XML-Token">FlashProgramSetup</td>
     <td>
     Optional setup before a program phase for a \ref element_flashinfo "flashinfo" region. The sequence can call
-    <b>FlashLoadAlgorithm</b> to select an FLM flash algorithm for the program phase. If the sequence is not implemented or
-    does not select an algorithm, the debugger uses the flash debug sequences for programming.
+    <b>FlashLoadAlgorithm</b> to select an FLM flash algorithm for the program phase. The debugger then uses the FLM functions
+    instead of the corresponding flash debug sequences. If no algorithm is selected, the debugger uses the flash debug sequences.
     </td>
   </tr>
   <tr>
     <td class="XML-Token">FlashInit</td>
     <td>
-    Executed before starting a flash operation.
+    Sequence-based counterpart of the FLM <b>Init</b> function. Executed before starting a flash operation.
     </td>
   </tr>
   <tr>
     <td class="XML-Token">FlashUninit</td>
     <td>
-    Executed after a flash operation finished.
+    Sequence-based counterpart of the FLM <b>UnInit</b> function. Executed after a flash operation finished.
     </td>
   </tr>
   <tr>
     <td class="XML-Token">FlashEraseSector</td>
     <td>
-    Executed to erase a flash memory sector.
+    Sequence-based counterpart of the FLM <b>EraseSector</b> function. Executed to erase a flash memory sector
+    described by a \ref element_flashinfo "flashinfo" region.
     </td>
   </tr>
   <tr>
     <td class="XML-Token">FlashEraseChip</td>
     <td>
-    Executed to erase all on-chip flash memory with target device specific erase technology. If this sequence is not implemented then a debugger can use <b>FlashEraseSector</b> to erase all flash memory.
+    Sequence-based counterpart of the FLM <b>EraseChip</b> function. Executed to erase all on-chip flash memory with
+    target device specific erase technology. If this sequence is not implemented then a debugger can use
+    <b>FlashEraseSector</b> to erase all flash memory.
     </td>
   </tr>
   <tr>
     <td class="XML-Token">FlashEraseDone</td>
     <td>
-    Executed after all flash memory erase operations are finished.
+    Executed after all flash memory erase operations are finished, regardless of whether flash debug sequences or an FLM flash
+    algorithm performed the operations.
     </td>
   </tr>
   <tr>
     <td class="XML-Token">FlashProgramPage</td>
     <td>
-    Executed to program a single flash page.
+    Sequence-based counterpart of the FLM <b>ProgramPage</b> function. Executed to program a single page described by
+    a \ref element_flashinfo "flashinfo" region.
     </td>
   </tr>
   <tr>
     <td class="XML-Token">FlashProgramDone</td>
     <td>
-    Executed after all flash programming operations are finished.
+    Executed after all flash programming operations are finished, regardless of whether flash debug sequences or an FLM flash
+    algorithm performed the operations.
     </td>
   </tr>
   <tr>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -825,6 +825,11 @@ algorithms must have a different name.
 
 Specify Flash information that the debugger can use to erase and program Flash memories without the use
 of target RAM based Flash download algorithms.<br>
+The \b FlashInit, \b FlashUninit, \b FlashEraseSector, \b FlashEraseChip, and \b FlashProgramPage
+\ref default_sequences "debug sequences" require one or more corresponding \b flashinfo regions, which supply the memory layout
+and programming parameters. Defining one or more \b flashinfo regions does not require any flash debug sequences to be
+implemented. If no flash debug sequences are implemented, the debugger ignores all such regions.<br>
+
 The child elements \<block> and \<gap> describe the memory and programming layout of a flash device:
 - The first child element has the base address \token{start}.
 - The base address of the second child element is \token{start} incremented by the size of the first child element.


### PR DESCRIPTION
Fixes #404 

Attempt to remove ambiguity from debug sequence specification wrt FLM based programming vs sequence based programming and which part flashinfo plays in here.

@tarek-bochkati wrote in #404 

> If an algorithm is defined
>
>    * programming should default to using that algorithm
>    * debug sequences should only be used if the user explicitly chooses that path

Unfortunately, this is no longer possible without wider or breaking changes. Note that we introduced debug sequence based programming in 2018 with a working assumption that a device can only do the one or the other. But never mix or give the user a choice.
The criterion to pick up sequence based algorithms for a device was to have `flashinfo` **_and_** flash debug sequences. However, in implementations we ignored `flashinfo` without flash sequences present. Which is now explicitly specified.

Due to this, the backwards compatible way wrt the debug sequence specification is to keep that approach. But allow to determine at runtime in `FlashEraseSetup` and `FlashProgramSetup` (see #408 ) if to load an FLM instead. That could be based on reading out a target state. Or even by asking the user via `Query` or `QueryValue` debug access functions.