### PR TITLE
Align rest of the doxygen with the schema file.

### DIFF
--- a/doxygen/src/apis_schema.txt
+++ b/doxygen/src/apis_schema.txt
@@ -1,7 +1,7 @@
 /**
 \page pdsc_apis_pg /package/apis element
 
-Application Programming Interfaces (apis) are C/C++ interface specifications that allow software to be divided into largely independent modules. 
+Application Programming Interfaces (apis) are C/C++ interface specifications that allow software to be divided into largely independent modules.
 Such modules can then be developed, tested, and maintained independently, and reused by different projects. One example is the use of device drivers.
 If device drivers are developed for different devices implementing the same API, the application software itself can be written independent from the
 device it is build for.
@@ -16,13 +16,13 @@ The API typically defines one or more header files and optionally an include dir
 \b Example:
 
 \code
-<api Cclass="ACloud IF" Cgroup="TRNG" Capiversion="1.2.0"> 
-  <files> 
-    <file category="header" name="include/trng.h"/> 
-    <file category="include" name="include/somestuff"/> 
-    <file category="doc" name="html/trng.html"/> 
-  </files> 
-</api> 
+<api Cclass="ACloud IF" Cgroup="TRNG" Capiversion="1.2.0">
+  <files>
+    <file category="header" name="include/trng.h"/>
+    <file category="include" name="include/somestuff"/>
+    <file category="doc" name="html/trng.html"/>
+  </files>
+</api>
 \endcode
 
 The API can be used either in the same software pack or other software packs. Having the API definition in one central software pack provides the
@@ -35,12 +35,12 @@ Therefore, the component that is based on the API should not contain the header 
 \b Example: this component adds also the api header file above
 
 \code
-<component Cclass="ACloud IF" Cgroup="TRNG" Csub="Emulation" Capiversion="1.1.0"> 
-  <description>Software simulation of random number generator</description> 
-  <files> 
-    <file category="sourceC" name="source/trng_emulation.c"/> 
-  </files> 
-</component> 
+<component Cclass="ACloud IF" Cgroup="TRNG" Csub="Emulation" Capiversion="1.1.0">
+  <description>Software simulation of random number generator</description>
+  <files>
+    <file category="sourceC" name="source/trng_emulation.c"/>
+  </files>
+</component>
 \endcode
 Optionally, it is possible to request a minimum API version using the \b Capiversion attribute.
 
@@ -63,7 +63,7 @@ The element itself is optional. Only one such section can exist in a package.
   <apis>
     ...
   </apis>
-</package>  
+</package>
 \endcode
 
 <p>&nbsp;</p>
@@ -100,7 +100,7 @@ The element itself is optional. Only one such section can exist in a package.
 
 \section element_api /package/apis/api
 
-Application Programming Interfaces (apis) are C/C++ interface specifications that allow components to inter-work 
+Application Programming Interfaces (apis) are C/C++ interface specifications that allow components to inter-work
 by either implementing or using a set of functions, data types, and definitions. This element is mandatory and can exist multiple times.
 
 \b Example:
@@ -143,14 +143,14 @@ by either implementing or using a set of functions, data types, and definitions.
   </tr>
   <tr>
     <td>Cclass</td>
-    <td>Defines the component class to which this component belongs. This is a mandatory part of the component ID.  
+    <td>Defines the component class to which this component belongs. This is a mandatory part of the component ID.
       Predefined values can be used as listed in the table \ref CclassType "Component Classes".</td>
     <td>CclassType</td>
     <td>required</td>
   </tr>
   <tr>
     <td>Cgroup</td>
-    <td>Defines the component group to which this component belongs. This is a mandatory part of the component ID. 
+    <td>Defines the component group to which this component belongs. This is a mandatory part of the component ID.
       Predefined values can be used as listed in the table \ref CgroupType "Component Groups".</td>
     <td>CgroupType</td>
     <td>required</td>
@@ -164,8 +164,8 @@ by either implementing or using a set of functions, data types, and definitions.
   </tr>
   <tr>
     <td>condition</td>
-    <td>Enter the identifier (attribute \em <b>id</b>) of a \ref element_condition "condition". The element is used if the condition resolves to \token{true}. 
-      If the condition resolves to \token{false}, then the element will be ignored. 
+    <td>Enter the identifier (attribute \em <b>id</b>) of a \ref element_condition "condition". The element is used if the condition resolves to \token{true}.
+      If the condition resolves to \token{false}, then the element will be ignored.
       For example, an API might be specific for a certain toolchain or processor instruction set.</td>
     <td>xs:string</td>
     <td>optional</td>
@@ -188,7 +188,7 @@ by either implementing or using a set of functions, data types, and definitions.
     <td>changelog</td>
     <td>
       Reference to the \token{changelog} with the given identifier \token{ID} specified in the changelogs section of the package description.
-      A changelog references a text file in the pack with a path relative to the pdsc containing changelog information for the api. 
+      A changelog references a text file in the pack with a path relative to the pdsc containing changelog information for the api.
       The content of the referenced changelog file is not required to be exclusively used for a single api.</td>
     <td>xs:string</td>
     <td>optional</td>
@@ -208,9 +208,9 @@ by either implementing or using a set of functions, data types, and definitions.
   </tr>
   <tr>
     <td>\ref element_files "files"</td>
-    <td>Grouping element for all file descriptions that are part of this component.</td>.
+    <td>Grouping element for all file descriptions that are part of this API. At least one \ref element_file "file" child element is required.</td>
     <td>group</td>
-    <td>0..1</td>
+    <td>1</td>
   </tr>
 </table>
 

--- a/doxygen/src/conditions_schema.txt
+++ b/doxygen/src/conditions_schema.txt
@@ -260,7 +260,7 @@ A \ref element_condition "condition" becomes \token{true} when:
   </tr>
   <tr>
     <td>Dcdecp</td>
-    <td>Specifies whether <a href="https://developer.arm.com/documentation/ddi0607/ab/" target="_blank">Custom Datapath Extension</a> Coprocessors and which coprocessor interfaces must be supported by the device. Possible values are explained in \ref DcdecpEnum "Custom Datapath Extensions".</td>
+    <td>Specifies whether <a href="https://support.arm.com/documentation/ddi0607/ab" target="_blank">Custom Datapath Extension</a> Coprocessors and which coprocessor interfaces must be supported by the device. Possible values are explained in \ref DcdecpEnum "Custom Datapath Extensions".</td>
     <td>\ref DcdecpEnum</td>
     <td>optional</td>
   </tr>

--- a/doxygen/src/conditions_schema.txt
+++ b/doxygen/src/conditions_schema.txt
@@ -1,13 +1,13 @@
 /**
 \page pdsc_conditions_pg /package/conditions element
 
-The grouping element \ref element_conditions contains all conditions defined for the software pack. 
+The grouping element \ref element_conditions contains all conditions defined for the software pack.
 
 A condition describes dependencies on device, processor, and tool attributes as well as the presence of other components.
 The <b>conditions</b> are used to define AND and OR rules used to make components conditional and therefore only available under certain circumstances,
 e.g. for specific devices or processors. The conditions are also used to express dependencies between components.
 
-Each condition has an <b>id</b> that is unique within the scope of a the description. An <b>id</b> can be referenced in the condition attribute of components, apis, 
+Each condition has an <b>id</b> that is unique within the scope of a the description. An <b>id</b> can be referenced in the condition attribute of components, apis,
 examples, files and other conditions to become conditional. If a condition resolves to false during the processing of the description, the respective element will
 be ignored.
 
@@ -149,7 +149,7 @@ If a condition resolves to \token{false}, then the component or file description
   </tr>
 </table>
 \note
-\b 1: At least one of these elements must be present in any condition.		
+\b 1: At least one of these elements must be present in any condition.
 
 <p>&nbsp;</p>
 <hr>
@@ -170,9 +170,9 @@ A \ref element_condition "condition" becomes \token{true} when:
     <th colspan="3">Chain</th>
   </tr>
   <tr>
-    <td>\ref element_condition "condition" 
+    <td>\ref element_condition "condition"
     <td colspan="3">\ref element_condition "/package/conditions/condition"</td>
-  </tr>  
+  </tr>
   <tr>
     <th>Attributes</th>
     <th>Description</th>
@@ -199,7 +199,7 @@ A \ref element_condition "condition" becomes \token{true} when:
   </tr>
   <tr>
     <td>Dname<b>*</b></td>
-    <td>Specifies the name of the device. 
+    <td>Specifies the name of the device.
    </td>
     <td>xs:string</td>
     <td>optional</td>
@@ -245,7 +245,7 @@ A \ref element_condition "condition" becomes \token{true} when:
     <td>Specifies whether the application is configured to run in secure or non-secure mode. Predefined values can be used as listed in the table \ref DsecureEnum "Software Model Secure".</td>
     <td>\ref DsecureEnum</td>
     <td>optional</td>
-  </tr> 
+  </tr>
   <tr>
     <td>Ddsp</td>
     <td>Specifies whether Digital Signal Processing (DSP) instruction set must be supported by the device or not. Predefined values can be uses as listed in the table \ref DdspEnum "Device DSP".</td>
@@ -320,7 +320,7 @@ A \ref element_condition "condition" becomes \token{true} when:
        - <b>deny Cversion:</b> condition is true if version of component is lower than requested.
        - Version ranges are specified with <em>min_version</em><b>:</b><em>max_version</em>. The condition is true if the version of the component is equal or higher than
          <em>min_version</em> and lower or equal than <em>max_version</em>. If <em>min_version</em> and <em>max_version</em> are equal the version must match exactly.
-       Note: Specifying the <em>min_version</em> e.g <em>Cversion="4.1.0"</em> is identical to the version range <em>Cversion="4.1.0:5.0.0-0"</em>.       
+       Note: Specifying the <em>min_version</em> e.g <em>Cversion="4.1.0"</em> is identical to the version range <em>Cversion="4.1.0:5.0.0-0"</em>.
     <td>\ref VersionType</td>
     <td>optional</td>
   </tr>
@@ -332,7 +332,7 @@ A \ref element_condition "condition" becomes \token{true} when:
        - <b>deny Capiversion:</b> condition is true if version of API is lower than requested.
        - Version ranges are specified with <em>min_version</em><b>:</b><em>max_version</em>. The condition is true if the version of the API is equal or higher than
          <em>min_version</em> and lower or equal than <em>max_version</em>. If <em>min_version</em> and <em>max_version</em> are equal the version must match exactly.
-       Note: Specifying the <em>min_version</em> e.g <em>Capiversion="4.1.0"</em> is identical to the version range <em>Capiversion="4.1.0:5.0.0-0"</em>.       
+       Note: Specifying the <em>min_version</em> e.g <em>Capiversion="4.1.0"</em> is identical to the version range <em>Capiversion="4.1.0:5.0.0-0"</em>.
     <td>\ref VersionType</td>
     <td>optional</td>
   </tr>
@@ -378,10 +378,17 @@ A \ref element_condition "condition" becomes \token{true} when:
         - <b>AC5</b>: Arm Compiler Version 5 is in used
         - <b>AC6</b>: Arm Compiler Version 6 (armclang) is in use
         - <b>AC6LTO</b>: Arm Compiler Version 6 with Link Time Optimization (LTO) is in use
-        
+
         This attribute can be used to select compatible libraries for the selected compiler version or optimization mode.
+        Note: can only be used in combination with \b Tcompiler.
     </td>
-    <td>\ref CompilerEnumType</td>
+    <td>\ref CompilerOptionsEnumType "CompilerOptionsEnumType"</td>
+    <td>optional</td>
+  </tr>
+  <tr>
+    <td>Toutput</td>
+    <td>Specifies the compiler output type. Use predefined values as listed in table \ref CompilerOutputType "Compiler Output Types".</td>
+    <td>\ref CompilerOutputType "CompilerOutputType"</td>
     <td>optional</td>
   </tr>
   <tr>
@@ -396,12 +403,12 @@ A \ref element_condition "condition" becomes \token{true} when:
        - '*'  matches any substring
        - '?'  matches any single character
        - [abc] matches any character in the set (a,b,c)
-   
+
 <b>**)</b> These attributes must not be used in conditions because
            - 'Dfamily' and 'DsubFamily' turn out to be volatile, meaning that silicon vendors have a trend to change the grouping of devices.
-           - conditions shall only filter for selectable devices. 'Dvariant'effectively is just an alias for 'Dname'. 
+           - conditions shall only filter for selectable devices. 'Dvariant'effectively is just an alias for 'Dname'.
              Once a \<variant> tag exists, the \<device> tag no longer represents a selectable device.
-   
+
 <p>&nbsp;</p>
 
 \anchor CompilerEnumType <b>Table: Compiler Types</b>
@@ -419,7 +426,7 @@ The tokens can be used in the elements:
   </tr>
   <tr>
     <td class="XML-Token">GCC</td>
-    <td>GNU Tools for Arm Embedded Processors. 
+    <td>GNU Tools for Arm Embedded Processors.
     Refer to <a href="https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain" target="_blank">Arm GCC</a>.</td>
   </tr>
   <tr>
@@ -428,7 +435,7 @@ The tokens can be used in the elements:
   </tr>
   <tr>
     <td class="XML-Token">ARMCC</td>
-    <td>Arm Compiler for C and C++. 
+    <td>Arm Compiler for C and C++.
     Refer to <a href="https://developer.arm.com/Tools%20and%20Software/Arm%20Compiler%20for%20Embedded" target="_blank">
     Arm Compiler for Embedded</a>.</td>
   </tr>
@@ -449,10 +456,22 @@ The tokens can be used in the elements:
     <td>Microchip MPLAB XC32 Compiler.</td>
   </tr>
   <tr>
+    <td class="XML-Token">Cosmic</td>
+    <td>Cosmic compiler for C and C++.</td>
+  </tr>
+  <tr>
      <td class="XML-Token">CLANG</td>
      <td>CLANG: a C language family frontend for LLVM for 32-bit Arm embedded targets. Refer to <a href="https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm" target="_blank">
          CLANG</a>
      </td>
+  </tr>
+  <tr>
+    <td class="XML-Token">Renesas</td>
+    <td>Renesas compiler for C and C++.</td>
+  </tr>
+  <tr>
+    <td class="XML-Token">CLANG_TI</td>
+    <td>CLANG-based TI compiler for C and C++.</td>
   </tr>
 </table>
 

--- a/doxygen/src/conditions_schema.txt
+++ b/doxygen/src/conditions_schema.txt
@@ -382,13 +382,13 @@ A \ref element_condition "condition" becomes \token{true} when:
         This attribute can be used to select compatible libraries for the selected compiler version or optimization mode.
         Note: can only be used in combination with \b Tcompiler.
     </td>
-    <td>\ref CompilerOptionsEnumType "CompilerOptionsEnumType"</td>
+    <td>"AC5", "AC6", "AC6LTO"</td>
     <td>optional</td>
   </tr>
   <tr>
     <td>Toutput</td>
-    <td>Specifies the compiler output type. Use predefined values as listed in table \ref CompilerOutputType "Compiler Output Types".</td>
-    <td>\ref CompilerOutputType "CompilerOutputType"</td>
+    <td>Specifies the compiler output type. Use predefined values `exe` or `lib`.</td>
+    <td>"exe", "lib"</td>
     <td>optional</td>
   </tr>
   <tr>

--- a/doxygen/src/pdsc_format.txt
+++ b/doxygen/src/pdsc_format.txt
@@ -405,7 +405,7 @@ assists searching for packages. An optional environments element can be used to 
 
 \anchor VersionType <b>Version Type</b>
 
-CMSIS-Pack version specification is inspired by the <a href="http://semver.org" target="_blank">Semantic Versioning 2.0.0</a>.
+CMSIS-Pack version specification is inspired by the <a href="https://semver.org" target="_blank">Semantic Versioning 2.0.0</a>.
 Under this scheme, version numbers and the way they are incremented convey a meaning about the underlying content quality and the significance
 of changes from one version to the next. A version consists of 3 mandatory and 2 optional sections:
 
@@ -520,9 +520,9 @@ This Markdown file is indented for web pages that offer software packs in form o
 A pack may be bound to export control: if so, the pack should provide the related Export Control Classification Numbers (ECCN)
 for both the United States and the European Union.
 
-This section describes the <a href="https://www.bis.doc.gov/index.php/licensing/commerce-control-list-classification/export-control-classification-number-eccn" target="_blank">Export Control Classification Numbers (ECCN)</a>
+This section describes the <a href="https://www.trade.gov/how-do-i-determine-my-export-control-classification-number-eccn" target="_blank">Export Control Classification Numbers (ECCN)</a>
 for the content of the pack for both the US and the EU.
-(For more information, please refer to the <a href="https://www.bis.gov/ccl-index" target="_blank">Commerce Control List (CCL) index</a>)
+(For more information, please refer to the <a href="https://www.bis.gov/regulations/ear/interactive-commerce-control-list" target="_blank">Commerce Control List (CCL) index</a>)
 
 \b Example:
 \code
@@ -555,13 +555,13 @@ for the content of the pack for both the US and the EU.
   </tr>
   <tr>
     <td>ECCN-EU</td>
-    <td>Defines the <a href="https://www.bis.doc.gov/index.php/documents/regulations-docs/13-commerce-control-list-index/file" target="_blank">Export Control Classification Number</a> for the European Union (EU)</td>
+    <td>Defines the <a href="https://www.bis.gov/licensing/classify-your-item" target="_blank">Export Control Classification Number</a> for the European Union (EU)</td>
     <td>ECCNEUCodeEnum</td>
     <td>1..1</td>
   </tr>
   <tr>
     <td>ECCN-US</td>
-    <td>Defines the <a href="https://www.bis.doc.gov/index.php/documents/regulations-docs/13-commerce-control-list-index/file" target="_blank">Export Control Classification Number</a> for the United States (US)</td>
+    <td>Defines the <a href="https://www.bis.gov/regulations/ear/interactive-commerce-control-list" target="_blank">Export Control Classification Number</a> for the United States (US)</td>
     <td>ECCNUSCodeEnum</td>
     <td>1..1</td>
   </tr>

--- a/doxygen/src/pdsc_format.txt
+++ b/doxygen/src/pdsc_format.txt
@@ -67,7 +67,7 @@ The \ref packFormat is structured using grouping elements and contains the follo
  - \subpage element_repository "<repository>": specifies the HTTPS URL and repository type of a public repository where the pack originates from.
  - \subpage element_dominate "<dominate>": the pack contains one or more device, API, or component that overrules other packs with identical items.
  - \subpage element_releases "<releases>": lists release versions with descriptions.
- - \subpage pdsc_changelogs_pg "<changeLogs>": lists changelog files associated with components and apis within the pack.
+ - \subpage pdsc_changelogs_pg "<changelogs>": lists changelog files associated with components and apis within the pack.
  - \subpage pdsc_licenseSets_pg "<licenseSets>": lists license files associated with the pack and contained components and apis.
  - \subpage element_requirements_pg "<requirements>": lists required packs, compiler, programming language standards and their version or version range.
  - \subpage element_taxonomy "<taxonomy>": lists description elements that define component classes and component group names.
@@ -83,7 +83,7 @@ The \ref packFormat is structured using grouping elements and contains the follo
  - \subpage pdsc_components_pg "<components>": lists the software components contained in the software pack.
  - \subpage pdsc_examples_pg "<examples>": specifies example projects contained in the pack.
  - \subpage pdsc_csolution_pg "<csolution>": lists pack content that relates to *csolution projects* that are managed using the <a href="https://github.com/Open-CMSIS-Pack/cmsis-toolbox" target="_blank">CMSIS-Toolbox</a>.
- 
+
 \section PDSC_Example Example of a *.pdsc File
 
 This example of a *.pdsc File explains the sections, particularly how dependencies are used to identify individual files of \ref cp_Components.
@@ -274,9 +274,9 @@ assists searching for packages. An optional environments element can be used to 
   </tr>
   <tr>
     <td>\ref element_dominate "dominate"</td>
-    <td>dominate</td>
-    <td>A pack that has \ref element_dominate "dominate" attribute overrules other packs that provide devices, APIs, or software components with the same name.</td>
-    <td>\em empty</td>
+    <td>A pack that has this element overrules other packs that provide identical \ref element_devices "device", \ref element_apis "API", or \ref element_components "component" definitions.</td>
+    <td>DominateType</td>
+    <td>0..1</td>
   </tr>
   <tr>
     <td>\ref element_requirements "requirements"</td>
@@ -658,8 +658,14 @@ specifies the repository technology and therefore the tools required to be used 
   <tr>
     <td>type</td>
     <td>Repository management technology used by the specified public repository (e.g. git, svn).</td>
-    <td>xs:string</td>
-    <td>required</td>
+    <td>
+      <ul>
+        <li>git</li>
+        <li>svn</li>
+        <li>other</li>
+      </ul>
+    </td>
+    <td>optional</td>
   </tr>
 </table>
 
@@ -720,7 +726,7 @@ This attribute is useful for framing packs that:
     <td>info</td>
     <td>Descriptive text that explains the reason for the overwrite using dominate.</td>
     <td>xs:string</td>
-    <td>optional</td>
+    <td>required</td>
   </tr>
 </table>
 

--- a/doxygen/src/pdsc_format.txt
+++ b/doxygen/src/pdsc_format.txt
@@ -1298,7 +1298,7 @@ and group \token{Startup} is defined for the device-specific CMSIS-Core (Cortex-
 \endcode
 
 \note You \b must \b not use Windows or Linux
-<a href="http://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words" target="_blank">reserved characters</a> for
+<a href="https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words" target="_blank">reserved characters</a> for
 \em Cclass, \em Cgroup, and \em Csub names! Some development tools use these names to create a directory structure for the
 software components in projects. Reserved characters are:
 \verbatim
@@ -1605,7 +1605,7 @@ It is recommended to use an already agreed part-taxonomy for interchangeable par
 \endcode
 
 \note You \b must \b not use Windows or Linux
-<a href="http://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words" target="_blank">reserved characters</a> for
+<a href="https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words" target="_blank">reserved characters</a> for
 \em Hclass, \em Hgroup, and \em Hsub names! Reserved characters are:
 \verbatim
 < (less than)


### PR DESCRIPTION
Note: this change was done by GPT 5.6 but reviewed by me
Removed superfluous spaces from doxygen source files.
Alignment of schema file with doxygen documentation.
