### PR TITLE
Trace buffers

### DIFF
--- a/doxygen/pack.dxy
+++ b/doxygen/pack.dxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Open-CMSIS-Pack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Version 1.7.60"
+PROJECT_NUMBER         = "Version 1.7.61"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -85,6 +85,7 @@ packs) and provides useful tips when creating a pack.
     <td>
       - added optional 'name' attributes to trace-sink elements
       - added named trace-buffer support for 'BufferStreamOut'
+      - added 'TraceSinkEnabled' debug access function
     </td>
   </tr>
   <tr>

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -81,6 +81,12 @@ packs) and provides useful tips when creating a pack.
     <th>Description</th>
   </tr>
   <tr>
+    <td>1.7.61</td>
+    <td>
+      - added named trace-buffer support for 'BufferStreamOut'
+    </td>
+  </tr>
+  <tr>
     <td>1.7.60</td>
     <td>
       - added 'FlashEraseSetup' and 'FlashProgramSetup' debug access sequences

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -85,7 +85,7 @@ packs) and provides useful tips when creating a pack.
     <td>
       - added optional 'name' attributes to trace-sink elements
       - added named trace-buffer support for 'BufferStreamOut'
-      - added 'TraceSinkEnabled' debug access function
+      - added 'TraceSinkSelected' debug access function
     </td>
   </tr>
   <tr>

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -83,7 +83,7 @@ packs) and provides useful tips when creating a pack.
   <tr>
     <td>1.7.61</td>
     <td>
-      - added optional 'name' attributes to trace-sink elements
+      - added optional 'name' attribute to tracebuffer elements
       - added Trace Buffer format to 'BufferStreamOut'
       - added 'TraceBufferSelected' debug access function
     </td>

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -83,7 +83,7 @@ packs) and provides useful tips when creating a pack.
   <tr>
     <td>1.7.61</td>
     <td>
-      - added optional 'name' attribute to tracebuffer elements
+      - added optional 'name' attribute to 'tracebuffer' element
       - added Trace Buffer format to 'BufferStreamOut'
       - added 'TraceBufferSelected' debug access function
     </td>

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -84,8 +84,8 @@ packs) and provides useful tips when creating a pack.
     <td>1.7.61</td>
     <td>
       - added optional 'name' attributes to trace-sink elements
-      - added named trace-buffer support for 'BufferStreamOut'
-      - added 'TraceSinkSelected' debug access function
+      - added Trace Buffer format to 'BufferStreamOut'
+      - added 'TraceBufferSelected' debug access function
     </td>
   </tr>
   <tr>

--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -83,6 +83,7 @@ packs) and provides useful tips when creating a pack.
   <tr>
     <td>1.7.61</td>
     <td>
+      - added optional 'name' attributes to trace-sink elements
       - added named trace-buffer support for 'BufferStreamOut'
     </td>
   </tr>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -1961,9 +1961,9 @@ debug access variables which are evaluated for the function call.
     </td>
   </tr>
   <tr>
-    <td style="white-space: nowrap"><pre>TraceSinkEnabled(type, name)</pre></td>
+    <td style="white-space: nowrap"><pre>TraceSinkSelected(type, name)</pre></td>
     <td>
-        Check whether a trace sink is enabled in the selected trace configuration.<br>
+        Check whether a trace sink is selected in the trace configuration.<br>
         <br>
         <b>Parameters:</b><br>
         - type: Constant string that specifies the trace sink type. It must be one of
@@ -1987,7 +1987,7 @@ debug access variables which are evaluated for the function call.
 
         <b>Code Example:</b><br>
         \code
-        <control if="TraceSinkEnabled(&quot;serialwire&quot;, &quot;SWO&quot;)">
+        <control if="TraceSinkSelected(&quot;serialwire&quot;, &quot;SWO&quot;)">
           <block>
             // Configure the device's SWO pin routing.
           </block>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -1961,6 +1961,41 @@ debug access variables which are evaluated for the function call.
     </td>
   </tr>
   <tr>
+    <td style="white-space: nowrap"><pre>TraceSinkEnabled(type, name)</pre></td>
+    <td>
+        Check whether a trace sink is enabled in the selected trace configuration.<br>
+        <br>
+        <b>Parameters:</b><br>
+        - type: Constant string that specifies the trace sink type. It must be one of
+          <b>"serialwire"</b>, <b>"traceport"</b>, or <b>"tracebuffer"</b>, matching the child elements of a
+          \refelem{trace} element.
+        - name: Constant string that identifies the trace sink. If the selected trace configuration contains exactly
+          one sink of the specified \b type, this parameter may be an empty string. If it contains multiple sinks of
+          that type, \b name shall identify one of them.
+        <br>
+        If the selected trace configuration contains an applicable \refelem{trace} element, the function evaluates
+        the matching child element. If no applicable <b>trace</b> element is specified, the function uses the default
+        default configuration, which has one unnamed sink of each type. In that case, an empty \b name selects the
+        sink and the result corresponds to the associated bit of \ref __traceout: bit 0 for <b>"serialwire"</b>, bit
+        1 for <b>"traceport"</b>, and bit 2 for <b>"tracebuffer"</b>. A non-empty \b name does not match a default
+        default sink.<br>
+        <br>
+        <b>Return Value:</b><br>
+        Returns \token{1} if the resolved trace sink is enabled; otherwise returns \token{0}. An empty \b name is an
+        error if the selected trace configuration contains multiple sinks of the specified type. An unsupported
+        \b type is also an error.
+
+        <b>Code Example:</b><br>
+        \code
+        <control if='TraceSinkEnabled("serialwire", "SWO")'>
+          <block>
+            // Configure the device's SWO pin routing.
+          </block>
+        </control>
+        \endcode
+    </td>
+  </tr>
+  <tr>
     <td style="white-space: nowrap"><pre>RunApplication (appPath, arguments, workDirectory, timeout)</pre></td>
     <td>
         Run an external application.<br>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -1935,19 +1935,18 @@ debug access variables which are evaluated for the function call.
         - buffID: Numeric buffer ID. Must be a constant number. Function fails if buffer does not exist.
         - buffOffset: First byte in the buffer to transfer to the external data sink.
         - length: Maximum number of bytes to stream out.
-        - path: Constant string value representing the destination to which to stream data. For the Binary File
-          format, refer to \ref charactersequence "character sequences" for path/file name place holders. For the
-          Trace Buffer format, this shall be the <b>name</b> of a
-          \refelem{trace_tracebuffer} element of the selected trace configuration. If that configuration has a
-          single <b>tracebuffer</b> element without a <b>name</b> attribute, <b>path</b> may be an empty string.
+        - path: Constant string value representing the destination to which to stream data.
+          - For the Binary File format, refer to \ref charactersequence "character sequences" for path/file name place holders.
+          - For the Trace Buffer format, this is the <b>name</b> of a specified \refelem{trace_tracebuffer} element representing
+            a data pipe into the debugger. If there is only a single unnamed <b>tracebuffer</b> element then an empty string may be used.
         - mode: Specifies how to treat the data sink in the specified mode.
           - Bit 0..3: Format of the data sink:<br>
-		    \token{0} - Binary File<br>
-		    \token{1} - Trace Buffer<br>
+		    \token{0} - Binary File: The sequence writes the data to a binary file in the host filesystem.<br>
+		    \token{1} - Trace Buffer: The sequence sends the data to a debugger-internal trace buffer for further processing.<br>
 			Others - Reserved<br>
-          - Bit 4..7: Communication options for data sink:<br>
+          - Bit 4..7: File write option (only applies to Binary File format; ignored for Trace Buffer format):<br>
 		    \token{0} - Overwrite<br>
-			\token{1} - Append<br>
+			  \token{1} - Append<br>
 			Others - Reserved<br>
         - timeout: Timeout in microseconds. If \token{0}, then synchronously wait for the operation to finish.<br>
           - This does not include file-system delays, e.g. between creation and visibility in a file browser. Use \b FilePathExists
@@ -1961,35 +1960,28 @@ debug access variables which are evaluated for the function call.
     </td>
   </tr>
   <tr>
-    <td style="white-space: nowrap"><pre>TraceSinkSelected(type, name)</pre></td>
+    <td style="white-space: nowrap"><pre>TraceBufferSelected(name)</pre></td>
     <td>
-        Check whether a trace sink is selected in the trace configuration.<br>
+        Check whether a trace buffer is selected in the trace configuration.<br>
         <br>
         <b>Parameters:</b><br>
-        - type: Constant string that specifies the trace sink type. It must be one of
-          <b>"serialwire"</b>, <b>"traceport"</b>, or <b>"tracebuffer"</b>, matching the child elements of a
-          \refelem{trace} element.
-        - name: Constant string that identifies the trace sink. If the selected trace configuration contains exactly
-          one sink of the specified \b type, this parameter may be an empty string. If it contains multiple sinks of
-          that type, \b name shall identify one of them.
+        - name: Constant string that identifies a named trace buffer. An empty string identifies the unnamed trace
+          buffer.
         <br>
-        If the selected trace configuration contains an applicable \refelem{trace} element, the function evaluates
-        the matching child element. If no applicable <b>trace</b> element is specified, the function uses the default
-        default configuration, which has one unnamed sink of each type. In that case, an empty \b name selects the
-        sink and the result corresponds to the associated bit of \ref __traceout: bit 0 for <b>"serialwire"</b>, bit
-        1 for <b>"traceport"</b>, and bit 2 for <b>"tracebuffer"</b>. A non-empty \b name does not match a default
-        default sink.<br>
+        Use the <b>name</b> attribute of the matching \refelem{trace_tracebuffer} element for a named trace buffer.
+        Use an empty string for the unnamed <b>tracebuffer</b> element. If no applicable <b>trace</b> element is
+        specified, the default configuration provides the unnamed trace buffer; its
+        selection corresponds to bit 2 of \ref __traceout.<br>
         <br>
         <b>Return Value:</b><br>
-        Returns \token{1} if the resolved trace sink is enabled; otherwise returns \token{0}. An empty \b name is an
-        error if the selected trace configuration contains multiple sinks of the specified type. An unsupported
-        \b type is also an error.
+        Returns \token{1} if the identified trace buffer is selected; otherwise returns \token{0}. An empty \b name is an
+        error if the selected trace configuration contains multiple trace buffers.
 
         <b>Code Example:</b><br>
         \code
-        <control if="TraceSinkSelected(&quot;serialwire&quot;, &quot;SWO&quot;)">
+        <control if="TraceBufferSelected(&quot;MyTraceBuffer&quot;)">
           <block>
-            // Configure the device's SWO pin routing.
+            // Read and forward trace data from the trace buffer called 'MyTraceBuffer'
           </block>
         </control>
         \endcode

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -1927,7 +1927,7 @@ debug access variables which are evaluated for the function call.
     </td>
   </tr>
   <tr>
-    <td style="white-space: nowrap"><pre>BufferStreamOut (buffID, buffOffset, length, destPath, destMode, timeout)</pre></td>
+    <td style="white-space: nowrap"><pre>BufferStreamOut (buffID, buffOffset, length, path, mode, timeout)</pre></td>
     <td>
         Stream data from a buffer to an external data sink, e.g. a file.<br>
         <br>
@@ -1935,11 +1935,15 @@ debug access variables which are evaluated for the function call.
         - buffID: Numeric buffer ID. Must be a constant number. Function fails if buffer does not exist.
         - buffOffset: First byte in the buffer to transfer to the external data sink.
         - length: Maximum number of bytes to stream out.
-        - path: Constant string value representing the destination to which to stream data to. Refer to
-		  \ref charactersequence "character sequences" for path/file name place holders.
-        - mode: Specifies how to treat the data source in the specified mode.
-          - Bit 0..3: Format of the data source:<br>
+        - path: Constant string value representing the destination to which to stream data. For the Binary File
+          format, refer to \ref charactersequence "character sequences" for path/file name place holders. For the
+          Trace Buffer format, this shall be the <b>name</b> of a
+          \refelem{trace_tracebuffer} element of the selected trace configuration. If that configuration has a
+          single <b>tracebuffer</b> element without a <b>name</b> attribute, <b>path</b> may be an empty string.
+        - mode: Specifies how to treat the data sink in the specified mode.
+          - Bit 0..3: Format of the data sink:<br>
 		    \token{0} - Binary File<br>
+		    \token{1} - Trace Buffer<br>
 			Others - Reserved<br>
           - Bit 4..7: Communication options for data sink:<br>
 		    \token{0} - Overwrite<br>

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -1946,7 +1946,7 @@ debug access variables which are evaluated for the function call.
 			Others - Reserved<br>
           - Bit 4..7: File write option (only applies to Binary File format; ignored for Trace Buffer format):<br>
 		    \token{0} - Overwrite<br>
-			  \token{1} - Append<br>
+		    \token{1} - Append<br>
 			Others - Reserved<br>
         - timeout: Timeout in microseconds. If \token{0}, then synchronously wait for the operation to finish.<br>
           - This does not include file-system delays, e.g. between creation and visibility in a file browser. Use \b FilePathExists

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -1987,7 +1987,7 @@ debug access variables which are evaluated for the function call.
 
         <b>Code Example:</b><br>
         \code
-        <control if='TraceSinkEnabled("serialwire", "SWO")'>
+        <control if="TraceSinkEnabled(&quot;serialwire&quot;, &quot;SWO&quot;)">
           <block>
             // Configure the device's SWO pin routing.
           </block>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -4559,8 +4559,8 @@ Multiple <b>trace</b> elements can be defined which are either specific to a pro
 <family Dfamily="LPC4300 Series" Dvendor="NXP:11">
   ...
   <trace Pname="Cortex-M4">
-    <serialwire/>
-    <traceport   width="0x0000000B"/> <!-- support for port widths 1, 2, and 4 -->
+    <serialwire name="SWO"/>
+    <traceport name="TPIU" width="0x0000000B"/> <!-- support for port widths 1, 2, and 4 -->
     <tracebuffer name="ETB" start="0x2000C000" size="0x4000"/>
   </trace>
   ...
@@ -4642,6 +4642,7 @@ Multiple <b>trace</b> elements can be defined which are either specific to a pro
 \section element_trace_serialwire /package/devices/family/.../trace/serialwire
 
 Indicates serial wire trace output capabilities of the specified processor.
+The optional <b>name</b> attribute identifies the trace sink.
 
 \b Example
 \code
@@ -4649,7 +4650,7 @@ Indicates serial wire trace output capabilities of the specified processor.
   ...
   <trace Pname="Cortex-M4">
     ...
-    <serialwire/>
+    <serialwire name="SWO"/>
     ...
   </trace>
   ...
@@ -4667,6 +4668,18 @@ Indicates serial wire trace output capabilities of the specified processor.
     <td>\ref element_trace "trace"</td>
     <td colspan="3">\ref element_trace</td>
   </tr>
+  <tr>
+    <th>Attributes</th>
+    <th>Description</th>
+    <th>Type</th>
+    <th>Use</th>
+  </tr>
+  <tr>
+    <td>name</td>
+    <td>Identifier of the serial wire trace sink.</td>
+    <td>RestrictedString</td>
+    <td>optional</td>
+  </tr>
 </table>
 
 <p>&nbsp;</p>		
@@ -4675,7 +4688,8 @@ Indicates serial wire trace output capabilities of the specified processor.
 \section element_trace_traceport /package/devices/family/.../trace/traceport
 
 Indicates parallel trace port output capabilities of the specified processor.
-This element describes possible configuration settings for capturing trace.
+This element describes possible configuration settings for capturing trace. The
+optional <b>name</b> attribute identifies the trace sink.
 
 \b Example
 \code
@@ -4683,7 +4697,7 @@ This element describes possible configuration settings for capturing trace.
   ...
   <trace Pname="Cortex-M4">
     ...
-    <traceport width="0x0000000B"/> <!-- support for port widths 1, 2, and 4 -->
+    <traceport name="TPIU" width="0x0000000B"/> <!-- support for port widths 1, 2, and 4 -->
     ...
   </trace>
   ...
@@ -4706,6 +4720,12 @@ This element describes possible configuration settings for capturing trace.
     <th>Description</th>
     <th>Type</th>
     <th>Use</th>
+  </tr>
+  <tr>
+    <td>name</td>
+    <td>Identifier of the parallel trace port sink.</td>
+    <td>RestrictedString</td>
+    <td>optional</td>
   </tr>
   <tr>
     <td>width</td>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -4710,13 +4710,6 @@ This element describes possible configuration settings for capturing trace.A
     <th>Use</th>
   </tr>
   <tr>
-    <td>name</td>
-    <td>Identifier of the parallel trace port sink. The parent <b>trace</b> element is expected to contain only one
-        <b>traceport</b> element.</td>
-    <td>RestrictedString</td>
-    <td>optional</td>
-  </tr>
-  <tr>
     <td>width</td>
     <td>
       Parallel trace port widths supported for the processor connection (see table below).

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -4676,7 +4676,7 @@ A <b>trace</b> element is expected to contain only one <b>serialwire</b> element
 \section element_trace_traceport /package/devices/family/.../trace/traceport
 
 Indicates parallel trace port output capabilities of the specified processor.
-This element describes possible configuration settings for capturing trace.A
+This element describes possible configuration settings for capturing trace. A
 <b>trace</b> element is expected to contain only one <b>traceport</b> element.
 
 \b Example

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -4642,7 +4642,10 @@ Multiple <b>trace</b> elements can be defined which are either specific to a pro
 \section element_trace_serialwire /package/devices/family/.../trace/serialwire
 
 Indicates serial wire trace output capabilities of the specified processor.
-The optional <b>name</b> attribute identifies the trace sink.
+The optional <b>name</b> attribute identifies the trace sink. If more than one
+<b>serialwire</b> element is specified for a <b>trace</b> element, every serial
+wire trace sink shall have a unique <b>name</b> attribute. A single serial wire
+trace sink may omit the attribute.
 
 \b Example
 \code
@@ -4676,7 +4679,8 @@ The optional <b>name</b> attribute identifies the trace sink.
   </tr>
   <tr>
     <td>name</td>
-    <td>Identifier of the serial wire trace sink.</td>
+    <td>Identifier of the serial wire trace sink. This attribute is required and shall be unique when the parent
+        <b>trace</b> element contains multiple <b>serialwire</b> elements.</td>
     <td>RestrictedString</td>
     <td>optional</td>
   </tr>
@@ -4689,7 +4693,10 @@ The optional <b>name</b> attribute identifies the trace sink.
 
 Indicates parallel trace port output capabilities of the specified processor.
 This element describes possible configuration settings for capturing trace. The
-optional <b>name</b> attribute identifies the trace sink.
+optional <b>name</b> attribute identifies the trace sink. If more than one
+<b>traceport</b> element is specified for a <b>trace</b> element, every parallel
+trace port sink shall have a unique <b>name</b> attribute. A single parallel
+trace port sink may omit the attribute.
 
 \b Example
 \code
@@ -4723,7 +4730,8 @@ optional <b>name</b> attribute identifies the trace sink.
   </tr>
   <tr>
     <td>name</td>
-    <td>Identifier of the parallel trace port sink.</td>
+    <td>Identifier of the parallel trace port sink. This attribute is required and shall be unique when the parent
+        <b>trace</b> element contains multiple <b>traceport</b> elements.</td>
     <td>RestrictedString</td>
     <td>optional</td>
   </tr>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -4841,7 +4841,7 @@ The value <b>width=0x00008088</b> (as shown in the table) indicates that three p
 Indicates on-device trace buffer capabilities of the specified processor.
 This element describes possible configuration settings for capturing trace
 and reading it from the buffer. The optional <b>name</b> attribute identifies
-the trace buffer for use with the \c BufferStreamOut debug access function.
+the trace buffer for use with the \c BufferStreamOut and \c TraceBufferSelected debug access functions.
 If more than one <b>tracebuffer</b> element is specified for a <b>trace</b>
 element, every trace buffer shall have a unique <b>name</b> attribute. A single
 trace buffer may omit the attribute.

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -4559,9 +4559,9 @@ Multiple <b>trace</b> elements can be defined which are either specific to a pro
 <family Dfamily="LPC4300 Series" Dvendor="NXP:11">
   ...
   <trace Pname="Cortex-M4">
-    <serialwire name="SWO"/>
-    <traceport name="TPIU" width="0x0000000B"/> <!-- support for port widths 1, 2, and 4 -->
-    <tracebuffer name="ETB" start="0x2000C000" size="0x4000"/>
+    <serialwire/>
+    <traceport width="0x0000000B"/> <!-- support for port widths 1, 2, and 4 -->
+    <tracebuffer start="0x2000C000" size="0x4000"/>
   </trace>
   ...
   <trace Pname="Cortex-M0">
@@ -4642,8 +4642,7 @@ Multiple <b>trace</b> elements can be defined which are either specific to a pro
 \section element_trace_serialwire /package/devices/family/.../trace/serialwire
 
 Indicates serial wire trace output capabilities of the specified processor.
-The optional <b>name</b> attribute identifies the trace sink. A <b>trace</b>
-element is expected to contain only one <b>serialwire</b> element.
+A <b>trace</b> element is expected to contain only one <b>serialwire</b> element.
 
 \b Example
 \code
@@ -4651,7 +4650,7 @@ element is expected to contain only one <b>serialwire</b> element.
   ...
   <trace Pname="Cortex-M4">
     ...
-    <serialwire name="SWO"/>
+    <serialwire/>
     ...
   </trace>
   ...
@@ -4669,19 +4668,6 @@ element is expected to contain only one <b>serialwire</b> element.
     <td>\ref element_trace "trace"</td>
     <td colspan="3">\ref element_trace</td>
   </tr>
-  <tr>
-    <th>Attributes</th>
-    <th>Description</th>
-    <th>Type</th>
-    <th>Use</th>
-  </tr>
-  <tr>
-    <td>name</td>
-    <td>Identifier of the serial wire trace sink. The parent <b>trace</b> element is expected to contain only one
-        <b>serialwire</b> element.</td>
-    <td>RestrictedString</td>
-    <td>optional</td>
-  </tr>
 </table>
 
 <p>&nbsp;</p>		
@@ -4690,9 +4676,8 @@ element is expected to contain only one <b>serialwire</b> element.
 \section element_trace_traceport /package/devices/family/.../trace/traceport
 
 Indicates parallel trace port output capabilities of the specified processor.
-This element describes possible configuration settings for capturing trace. The
-optional <b>name</b> attribute identifies the trace sink. A <b>trace</b>
-element is expected to contain only one <b>traceport</b> element.
+This element describes possible configuration settings for capturing trace.A
+<b>trace</b> element is expected to contain only one <b>traceport</b> element.
 
 \b Example
 \code
@@ -4700,7 +4685,7 @@ element is expected to contain only one <b>traceport</b> element.
   ...
   <trace Pname="Cortex-M4">
     ...
-    <traceport name="TPIU" width="0x0000000B"/> <!-- support for port widths 1, 2, and 4 -->
+    <traceport width="0x0000000B"/> <!-- support for port widths 1, 2, and 4 -->
     ...
   </trace>
   ...

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -4642,10 +4642,8 @@ Multiple <b>trace</b> elements can be defined which are either specific to a pro
 \section element_trace_serialwire /package/devices/family/.../trace/serialwire
 
 Indicates serial wire trace output capabilities of the specified processor.
-The optional <b>name</b> attribute identifies the trace sink. If more than one
-<b>serialwire</b> element is specified for a <b>trace</b> element, every serial
-wire trace sink shall have a unique <b>name</b> attribute. A single serial wire
-trace sink may omit the attribute.
+The optional <b>name</b> attribute identifies the trace sink. A <b>trace</b>
+element is expected to contain only one <b>serialwire</b> element.
 
 \b Example
 \code
@@ -4679,8 +4677,8 @@ trace sink may omit the attribute.
   </tr>
   <tr>
     <td>name</td>
-    <td>Identifier of the serial wire trace sink. This attribute is required and shall be unique when the parent
-        <b>trace</b> element contains multiple <b>serialwire</b> elements.</td>
+    <td>Identifier of the serial wire trace sink. The parent <b>trace</b> element is expected to contain only one
+        <b>serialwire</b> element.</td>
     <td>RestrictedString</td>
     <td>optional</td>
   </tr>
@@ -4693,10 +4691,8 @@ trace sink may omit the attribute.
 
 Indicates parallel trace port output capabilities of the specified processor.
 This element describes possible configuration settings for capturing trace. The
-optional <b>name</b> attribute identifies the trace sink. If more than one
-<b>traceport</b> element is specified for a <b>trace</b> element, every parallel
-trace port sink shall have a unique <b>name</b> attribute. A single parallel
-trace port sink may omit the attribute.
+optional <b>name</b> attribute identifies the trace sink. A <b>trace</b>
+element is expected to contain only one <b>traceport</b> element.
 
 \b Example
 \code
@@ -4730,8 +4726,8 @@ trace port sink may omit the attribute.
   </tr>
   <tr>
     <td>name</td>
-    <td>Identifier of the parallel trace port sink. This attribute is required and shall be unique when the parent
-        <b>trace</b> element contains multiple <b>traceport</b> elements.</td>
+    <td>Identifier of the parallel trace port sink. The parent <b>trace</b> element is expected to contain only one
+        <b>traceport</b> element.</td>
     <td>RestrictedString</td>
     <td>optional</td>
   </tr>

--- a/doxygen/src/devices_schema.txt
+++ b/doxygen/src/devices_schema.txt
@@ -4561,7 +4561,7 @@ Multiple <b>trace</b> elements can be defined which are either specific to a pro
   <trace Pname="Cortex-M4">
     <serialwire/>
     <traceport   width="0x0000000B"/> <!-- support for port widths 1, 2, and 4 -->
-    <tracebuffer start="0x2000C000" size="0x4000"/>
+    <tracebuffer name="ETB" start="0x2000C000" size="0x4000"/>
   </trace>
   ...
   <trace Pname="Cortex-M0">
@@ -4838,15 +4838,20 @@ The value <b>width=0x00008088</b> (as shown in the table) indicates that three p
 
 Indicates on-device trace buffer capabilities of the specified processor.
 This element describes possible configuration settings for capturing trace
-and reading it from the buffer.
+and reading it from the buffer. The optional <b>name</b> attribute identifies
+the trace buffer for use with the \c BufferStreamOut debug access function.
+If more than one <b>tracebuffer</b> element is specified for a <b>trace</b>
+element, every trace buffer shall have a unique <b>name</b> attribute. A single
+trace buffer may omit the attribute.
 
-\b Example
+\b Example for an LPC812 device. The MTB uses a configurable region of RAM; this example reserves its complete
+4 KB SRAM region for trace capture.
 \code
-<family Dfamily="LPC4300 Series" Dvendor="NXP:11">
+<family Dfamily="LPC800" Dvendor="NXP:11">
   ...
-  <trace Pname="CoreCM4">
+  <trace>
     ...
-    <tracebuffer start="0x2000C000" size="0x4000"/>
+    <tracebuffer name="MTB" start="0x10000000" size="0x1000"/>
     ...
   </trace>
   ...
@@ -4869,6 +4874,13 @@ and reading it from the buffer.
     <th>Description</th>
     <th>Type</th>
     <th>Use</th>
+  </tr>
+  <tr>
+    <td>name</td>
+    <td>Identifier of the trace buffer. This attribute is required and shall be unique when the parent
+        <b>trace</b> element contains multiple <b>tracebuffer</b> elements.</td>
+    <td>RestrictedString</td>
+    <td>optional</td>
   </tr>
   <tr>
     <td>start</td>

--- a/doxygen/src/pack_dbg_setup_tutorial.txt
+++ b/doxygen/src/pack_dbg_setup_tutorial.txt
@@ -316,7 +316,7 @@ incrementing its address, and streams the result to the trace buffer named <b>ET
 
 <sequences>
   <sequence name="TraceFlush">
-    <control if="TraceSinkEnabled(&quot;tracebuffer&quot;, &quot;ETB&quot;)">
+    <control if="TraceSinkSelected(&quot;tracebuffer&quot;, &quot;ETB&quot;)">
       <block>
         // Read 0x100 bytes from a fixed 32-bit trace-data register into buffer 0.
         // Mode 32 selects 32-bit reads; its increment bit is clear.

--- a/doxygen/src/pack_dbg_setup_tutorial.txt
+++ b/doxygen/src/pack_dbg_setup_tutorial.txt
@@ -316,11 +316,11 @@ incrementing its address, and streams the result to the trace buffer named <b>ET
 
 <sequences>
   <sequence name="TraceFlush">
-    <control if="TraceSinkSelected(&quot;tracebuffer&quot;, &quot;ETB&quot;)">
+    <control if="TraceBufferSelected(&quot;ETB&quot;)">
       <block>
         // Read 0x100 bytes from a fixed 32-bit trace-data register into buffer 0.
         // Mode 32 selects 32-bit reads; its increment bit is clear.
-        BufferRead(0, 0, 0x50000000, 0x100, 32);
+        BufferRead(0, 0, 0xE0042010, 0x100, 32);
         BufferStreamOut(0, 0, 0x100, "ETB", 1, 0);
       </block>
     </control>

--- a/doxygen/src/pack_dbg_setup_tutorial.txt
+++ b/doxygen/src/pack_dbg_setup_tutorial.txt
@@ -314,14 +314,18 @@ incrementing its address, and streams the result to the trace buffer named <b>ET
   <tracebuffer name="ETB"/>
 </trace>
 
-<sequence name="TraceFlush">
-  <block>
-    // Read 0x100 bytes from a fixed 32-bit trace-data register into buffer 0.
-    // Mode 32 selects 32-bit reads; its increment bit is clear.
-    BufferRead(0, 0, 0x50000000, 0x100, 32);
-    BufferStreamOut(0, 0, 0x100, "ETB", 1, 0);
-  </block>
-</sequence>
+<sequences>
+  <sequence name="TraceFlush">
+    <control if="TraceSinkEnabled(&quot;tracebuffer&quot;, &quot;ETB&quot;)">
+      <block>
+        // Read 0x100 bytes from a fixed 32-bit trace-data register into buffer 0.
+        // Mode 32 selects 32-bit reads; its increment bit is clear.
+        BufferRead(0, 0, 0x50000000, 0x100, 32);
+        BufferStreamOut(0, 0, 0x100, "ETB", 1, 0);
+      </block>
+    </control>
+  </sequence>
+</sequences>
 \endcode
 
 \section dbg_sqns_reset Implement reset for debug access

--- a/doxygen/src/pack_dbg_setup_tutorial.txt
+++ b/doxygen/src/pack_dbg_setup_tutorial.txt
@@ -297,6 +297,33 @@ Below is a simple example of \c EnableTraceSWO for Microchip SAMS70 family, that
 
 Some devices can require that trace clock is enabled already at \ref DebugDeviceUnlock sequence to ensure that access to global trace components is available when reading the ROM table and processor features. In such cases corresponding functionality needs to be moved from \b TraceStart to \b DebugDeviceUnlock sequence and check if trace is enabled via the \b __traceout variable.
 
+\section dbg_sqns_tracebuffer Stream trace data to a trace buffer
+
+An on-device trace buffer can be described with a \refelem{trace_tracebuffer} element. If the trace
+configuration provides multiple trace buffers, assign each one a unique <b>name</b>. A debug access
+sequence can collect trace data in a temporary buffer using \c BufferRead and deliver it to the
+selected trace buffer using \c BufferStreamOut with the Trace Buffer format (mode \token{1}). The
+\b path argument selects the trace buffer by name. For a configuration with one unnamed
+<b>tracebuffer</b> element, use an empty string for \b path.
+
+The following example reads 32-bit values repeatedly from a fixed trace-data register, without
+incrementing its address, and streams the result to the trace buffer named <b>ETB</b>:
+
+\code
+<trace Pname="Cortex-M4">
+  <tracebuffer name="ETB"/>
+</trace>
+
+<sequence name="TraceFlush">
+  <block>
+    // Read 0x100 bytes from a fixed 32-bit trace-data register into buffer 0.
+    // Mode 32 selects 32-bit reads; its increment bit is clear.
+    BufferRead(0, 0, 0x50000000, 0x100, 32);
+    BufferStreamOut(0, 0, 0x100, "ETB", 1, 0);
+  </block>
+</sequence>
+\endcode
+
 \section dbg_sqns_reset Implement reset for debug access
 
 This section explains reset debug sequences for systems with a single CPU. Multi-core specifics are covered in \ref dbg_sqns_multicore.

--- a/doxygen/src/pack_dbg_setup_tutorial.txt
+++ b/doxygen/src/pack_dbg_setup_tutorial.txt
@@ -299,12 +299,16 @@ Some devices can require that trace clock is enabled already at \ref DebugDevice
 
 \section dbg_sqns_tracebuffer Stream trace data to a trace buffer
 
-An on-device trace buffer can be described with a \refelem{trace_tracebuffer} element. If the trace
-configuration provides multiple trace buffers, assign each one a unique <b>name</b>. A debug access
-sequence can collect trace data in a temporary buffer using \c BufferRead and deliver it to the
-selected trace buffer using \c BufferStreamOut with the Trace Buffer format (mode \token{1}). The
-\b path argument selects the trace buffer by name. For a configuration with one unnamed
-<b>tracebuffer</b> element, use an empty string for \b path.
+Use a \refelem{trace_tracebuffer} element to describe an on-device trace buffer. A single trace
+buffer may be unnamed. If a trace configuration provides multiple trace buffers, each one shall
+have a unique <b>name</b> attribute.
+
+Use the name with \c BufferStreamOut in the Trace Buffer format (mode \token{1}) and with
+\c TraceBufferSelected. An empty string identifies the unnamed trace buffer.
+
+A debug access sequence can collect trace data in a temporary buffer using \c BufferRead and
+forward it with \c BufferStreamOut to the selected trace buffer in the debugger for further
+processing.
 
 The following example reads 32-bit values repeatedly from a fixed trace-data register, without
 incrementing its address, and streams the result to the trace buffer named <b>ETB</b>:

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -28,6 +28,7 @@
   17. Aug 2026: v1.7.61
    - added optional 'name' attribute to trace sink elements
    - added named trace-buffer support for 'BufferStreamOut'
+   - added 'TraceSinkEnabled' debug access function
   22. Jul 2026: v1.7.60
    - added 'FlashEraseSetup' and 'FlashProgramSetup' debug access sequences
    - added 'FlashLoadAlgorithm' debug access function

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -26,7 +26,8 @@
   SchemaVersion=1.7.61
 
   17. Aug 2026: v1.7.61
-   - added optional 'name' attribute to 'tracebuffer' element
+   - added optional 'name' attribute to trace sink elements
+   - added named trace-buffer support for 'BufferStreamOut'
   22. Jul 2026: v1.7.60
    - added 'FlashEraseSetup' and 'FlashProgramSetup' debug access sequences
    - added 'FlashLoadAlgorithm' debug access function
@@ -795,11 +796,13 @@
 
   <!-- SerialWireType -->
   <xs:complexType name="SerialWireType">
+    <xs:attribute name="name" type="RestrictedString" use="optional" />
     <xs:anyAttribute processContents="lax" />
   </xs:complexType>
 
   <!-- TracePortType -->
   <xs:complexType name="TracePortType">
+    <xs:attribute name="name" type="RestrictedString" use="optional" />
     <xs:attribute name="width" type="NonNegativeInteger" use="optional" />
     <xs:anyAttribute processContents="skip" />
   </xs:complexType>

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -25,7 +25,7 @@
   Package file name convention <vendor>.<name>.<version>.pack
   SchemaVersion=1.7.61
 
-  17. Aug 2026: v1.7.61
+  18. Aug 2026: v1.7.61
    - added optional 'name' attribute to trace sink elements
    - added named trace-buffer support for 'BufferStreamOut'
    - added 'TraceSinkSelected' debug access function

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -18,7 +18,7 @@
   limitations under the License.
 
 
-  $Date:        17. August 2026
+  $Date:        18. August 2026
   $Revision:    1.7.61
   $Project: Schema File for Package Description File Format Specification
 
@@ -28,7 +28,7 @@
   17. Aug 2026: v1.7.61
    - added optional 'name' attribute to trace sink elements
    - added named trace-buffer support for 'BufferStreamOut'
-   - added 'TraceSinkEnabled' debug access function
+   - added 'TraceSinkSelected' debug access function
   22. Jul 2026: v1.7.60
    - added 'FlashEraseSetup' and 'FlashProgramSetup' debug access sequences
    - added 'FlashLoadAlgorithm' debug access function

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -18,17 +18,17 @@
   limitations under the License.
 
 
-  $Date:        18. August 2026
+  $Date:        20. August 2026
   $Revision:    1.7.61
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
   SchemaVersion=1.7.61
 
-  18. Aug 2026: v1.7.61
+  20. Aug 2026: v1.7.61
    - added optional 'name' attribute to trace sink elements
-   - added named trace-buffer support for 'BufferStreamOut'
-   - added 'TraceSinkSelected' debug access function
+   - added Trace Buffer format to 'BufferStreamOut'
+   - added 'TraceBufferSelected' debug access function
   22. Jul 2026: v1.7.60
    - added 'FlashEraseSetup' and 'FlashProgramSetup' debug access sequences
    - added 'FlashLoadAlgorithm' debug access function

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -18,13 +18,15 @@
   limitations under the License.
 
 
-  $Date:        22. July 2026
-  $Revision:    1.7.60
+  $Date:        17. August 2026
+  $Revision:    1.7.61
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
-  SchemaVersion=1.7.60
+  SchemaVersion=1.7.61
 
+  17. Aug 2026: v1.7.61
+   - added optional 'name' attribute to 'tracebuffer' element
   22. Jul 2026: v1.7.60
    - added 'FlashEraseSetup' and 'FlashProgramSetup' debug access sequences
    - added 'FlashLoadAlgorithm' debug access function
@@ -277,7 +279,7 @@
 
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.60">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified" version="1.7.61">
 
   <!-- NonNegativeInteger specifies the format in which numbers are represented in hexadecimal or decimal format -->
   <xs:simpleType name="NonNegativeInteger">
@@ -804,6 +806,7 @@
 
   <!-- TraceBufferType -->
   <xs:complexType name="TraceBufferType">
+    <xs:attribute name="name" type="RestrictedString" use="optional" />
     <xs:attribute name="start" type="NonNegativeInteger" use="optional" />
     <xs:attribute name="size" type="NonNegativeInteger" use="optional" />
     <xs:anyAttribute processContents="skip" />

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -18,14 +18,14 @@
   limitations under the License.
 
 
-  $Date:        20. August 2026
+  $Date:        21. August 2026
   $Revision:    1.7.61
   $Project: Schema File for Package Description File Format Specification
 
   Package file name convention <vendor>.<name>.<version>.pack
   SchemaVersion=1.7.61
 
-  20. Aug 2026: v1.7.61
+  21. Aug 2026: v1.7.61
    - added optional 'name' attribute to 'tracebuffer' element
    - added Trace Buffer format to 'BufferStreamOut'
    - added 'TraceBufferSelected' debug access function

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -26,7 +26,7 @@
   SchemaVersion=1.7.61
 
   20. Aug 2026: v1.7.61
-   - added optional 'name' attribute to trace sink elements
+   - added optional 'name' attribute to tracebuffer elements
    - added Trace Buffer format to 'BufferStreamOut'
    - added 'TraceBufferSelected' debug access function
   22. Jul 2026: v1.7.60
@@ -797,13 +797,11 @@
 
   <!-- SerialWireType -->
   <xs:complexType name="SerialWireType">
-    <xs:attribute name="name" type="RestrictedString" use="optional" />
     <xs:anyAttribute processContents="lax" />
   </xs:complexType>
 
   <!-- TracePortType -->
   <xs:complexType name="TracePortType">
-    <xs:attribute name="name" type="RestrictedString" use="optional" />
     <xs:attribute name="width" type="NonNegativeInteger" use="optional" />
     <xs:anyAttribute processContents="skip" />
   </xs:complexType>

--- a/schema/PACK.xsd
+++ b/schema/PACK.xsd
@@ -26,7 +26,7 @@
   SchemaVersion=1.7.61
 
   20. Aug 2026: v1.7.61
-   - added optional 'name' attribute to tracebuffer elements
+   - added optional 'name' attribute to 'tracebuffer' element
    - added Trace Buffer format to 'BufferStreamOut'
    - added 'TraceBufferSelected' debug access function
   22. Jul 2026: v1.7.60


### PR DESCRIPTION
Contributes to
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/1069

- Proposal to distinguish different trace buffers in PDSC file.
- Add debug access function `TraceBufferSelected` to decide in sequences which buffers are selected and in use. `__traceout` no longer powerful enough to express such conditions.
- Complemented by https://github.com/Open-CMSIS-Pack/cmsis-toolbox/pull/675