### PR TITLE
Add halt-after-reset context for reset sequences

### DIFF
--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -81,6 +81,12 @@ packs) and provides useful tips when creating a pack.
     <th>Description</th>
   </tr>
   <tr>
+    <td>Next Version</td>
+    <td>
+      - added use of `__connection` Bit 18 as halt-after-reset indicator
+    </td>
+  </tr>
+  <tr>
     <td>1.7.62</td>
     <td>
       - removed optional 'Pname' attribute from 'trace' element

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -87,6 +87,14 @@ The following diagrams show how the Debug Access Sequences are executed by a dev
 
 <b>Reset Device</b> is executed to reset the target.
 
+The debugger decides whether the CPU is expected to halt after reset. If a halt is expected,
+<b>ResetCatchSet</b> is called before and <b>ResetCatchClear</b> after the reset. Otherwise,
+neither sequence is called and the CPU continues to run.<br>
+The debugger passes the same decision to the reset sequence in <b>__connection</b> bit 18
+(set for halt, clear for run).
+This indicator allows the reset sequence to coordinate the halt with custom reset or boot hardware,
+or to halt the CPU itself; it does not control the reset catch configuration.
+
 \image html Reset.png
 
 <b>Verify Code</b> is executed to verify the content after flash programming.
@@ -2149,7 +2157,8 @@ A debugger needs to support a set of pre-defined debug access variables. These a
         - \token{3}: Processor Reset Request ("Vector Reset").
       - Bit 16: Connection under Hardware Reset (debugger reset line)
       - Bit 17: Hardware Reset is executed as a pre-connection reset (only used for debugger calls to \c ResetHardware)
-      - Bit 18..63: Reserved
+      - Bit 18: Reset sequence is expected to finish with the CPU halted in Debug state (only used for debugger calls to reset sequences)
+      - Bit 19..63: Reserved
     </td>
   </tr>
   <tr>

--- a/doxygen/src/pack_dbg_setup_tutorial.txt
+++ b/doxygen/src/pack_dbg_setup_tutorial.txt
@@ -489,6 +489,36 @@ In some cases the \b ResetCatchSet sequence shall behave differently depending o
 
 The \b ResetCatchClear sequence from \ref example1_resetCatchClear "Example 1" can also be used with the \ref example2_resetCatchSet "Example 2: ResetCatchSet" as there's no special handling additionally required.
 
+\anchor example3_resetSystem
+<b>Example 3: Use the CPU halt indicator in ResetSystem</b>
+
+The following custom Cortex-M implementation uses <b>__connection</b> bit 18 to force the CPU
+to halt when requested by setting <b>C_HALT</b> in the Debug Halting Control and Status Register (DHCSR):
+
+\code
+<sequence name="ResetSystem">
+  <block>
+    __var AIRCR_Addr = 0xE000ED0C;
+    __var DHCSR_Addr = 0xE000EDF0;
+
+    Write32(AIRCR_Addr, 0x05FA0004);  // Execute SYSRESETREQ via AIRCR
+    DAP_Delay(100000);
+  </block>
+
+  <!-- Reset Recovery: Wait for DHCSR.S_RESET_ST bit to clear on read -->
+  <control while="(Read32(DHCSR_Addr) &amp; 0x02000000)" timeout="500000"/>
+
+  <!-- Force halt only if requested and DHCSR.S_HALT is clear -->
+  <control if="(__connection &amp; 0x00040000) &amp;&amp; !(Read32(DHCSR_Addr) &amp; 0x00020000)">
+    <block>
+      // Write DBGKEY, C_DEBUGEN, and C_HALT to force debug halt
+      Write32(DHCSR_Addr, 0xA05F0003);
+    </block>
+    <control while="!(Read32(DHCSR_Addr) &amp; 0x00020000)" timeout="500000"/>
+  </control>
+</sequence>
+\endcode
+
 <b>Other modifications</b>
 
 Additionally the reset behavior can be made configurable per project via custom global debug access variables and a *.dbgconf file. See \ref dbg_sqns_dbgconf for additional details.


### PR DESCRIPTION
Fixes #417 

Adds `__connection` bit 18 to indicate if a debugger expects the CPU to be halted after reset.
Adds an example to the debug sequence tutorial.