### PR TITLE
Add rules for AP/DP register caching

### DIFF
--- a/doxygen/src/General.txt
+++ b/doxygen/src/General.txt
@@ -81,6 +81,12 @@ packs) and provides useful tips when creating a pack.
     <th>Description</th>
   </tr>
   <tr>
+    <td>Next Version</td>
+    <td>
+      - added rules for AP/DP register caching
+    </td>
+  </tr>
+  <tr>
     <td>1.7.62</td>
     <td>
       - removed optional 'Pname' attribute from 'trace' element

--- a/doxygen/src/debug_description.txt
+++ b/doxygen/src/debug_description.txt
@@ -2327,6 +2327,19 @@ A debugger needs to support a set of pre-defined debug access variables. These a
   </tr>
 </table>
 
+\subsection DebugRegisterCaching Caching of DP and AP registers
+
+The \ref DebugFunctions "debug access functions" access target memory or directly access DP and AP registers using
+\c ReadAP, \c WriteAP, \c ReadAccessAP, \c WriteAccessAP, \c ReadDP, \c WriteDP, and \c DAP_WriteABORT.
+
+To accelerate target memory accesses, a host debugger may cache DP and AP registers such as the AP CSW and DP SELECT.
+If a debugger implements such caching, the direct register access functions listed above must behave as follows:
+
+- A direct register read must always access the target register rather than return a cached value. The debugger must update
+  the corresponding register cache with the latest value read from the target.
+- A direct register write must always access the target register and update the corresponding register cache with the written
+  value. This is particularly important for write-only registers such as DP SELECT.
+
 \subsection externalTools Using external tools
 
 Some functionality cannot be implemented by debug sequences, for example checksum/hash calculations or debug authentication.

--- a/doxygen/src/pack_dbg_setup_tutorial.txt
+++ b/doxygen/src/pack_dbg_setup_tutorial.txt
@@ -361,10 +361,40 @@ The reset types are listed below with details described in the referenced docume
  - \ref resetProcessor_Descr "ResetProcessor" is a software-triggered local reset for a processor only.
  - \b CustomResetName sequence is used when a user-defined debug sequence is assigned to the \ref defaultResetSequence attribute. This can be implemented when very special reset type is needed that cannot be performed by modifying predefined reset types.
 
+<b>Resynchronize cached AP registers after reset</b>
+
+A reset might clear AP registers such as the CSW. If the host debugger caches the AP CSW to accelerate memory accesses,
+the cached value must be resynchronized before the next memory access. The following device-specific \b ResetSystem example
+performs an explicit AP CSW read after the reset delay. As described in \ref DebugRegisterCaching, \c ReadAP updates the
+debugger's internal AP CSW cache with the value read from the target:
+
+\code
+<sequence name="ResetSystem">
+  <block>
+    // System Control Space (SCS) offset as defined in Armv6-M/Armv7-M.
+    __var SCS_Addr   = 0xE000E000;
+    __var AIRCR_Addr = SCS_Addr + 0xD0C;
+    __var DHCSR_Addr = SCS_Addr + 0xDF0;
+
+    // Execute SYSRESETREQ via AIRCR.
+    Write32(AIRCR_Addr, 0x05FA0004);
+
+    // Delay for 100 ms to let the system reset complete.
+    DAP_Delay(100000);
+
+    // Read AP CSW from the target and refresh the debugger's internal cache.
+    ReadAP(0x00);
+  </block>
+
+  <!-- Reset Recovery: Wait for DHCSR.S_RESET_ST bit to clear on read. -->
+  <control while="(Read32(DHCSR_Addr) &amp; 0x02000000)" timeout="500000"/>
+</sequence>
+\endcode
+
 \anchor dbg_sqns_reset_catchClear
 <b>CPU halt and ResetCatchClear</b>
 
-After reset is performed and the processor is halted (on the breakpoint enabled in \b ResetCatchSet) the \ref resetCatchClear sequence is executed. The default implementation may need to be overwritten to support bootloader as explaine in \ref dbg_sqns_boot.
+After reset is performed and the processor is halted (on the breakpoint enabled in \b ResetCatchSet) the \ref resetCatchClear sequence is executed. The default implementation may need to be overwritten to support bootloader as explained in \ref dbg_sqns_boot.
 
 \section dbg_sqns_boot Support bootloader operation
 


### PR DESCRIPTION
Debuggers can cache AP/DP register values to for example accelerate target memory access by skipping unchanged AP CSW or DP SELECT values.

This PR adds rules for a how a debugger should interact with such host-side caching when using debug access functions.